### PR TITLE
Harden repo protections and deployment workflow

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# Protect workflow and repository-governance changes.
+/.github/CODEOWNERS @TheSchlote
+/.github/workflows/ @TheSchlote
+/.github/ @TheSchlote

--- a/.github/workflows/build-and-deploy-itch.yml
+++ b/.github/workflows/build-and-deploy-itch.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    branches:
+      - main
+  merge_group:
   workflow_dispatch:
 
 permissions:
@@ -203,6 +207,10 @@ jobs:
           versioning: Custom
           version: ${{ env.BUILD_VERSION }}
 
+      - name: Fix build output ownership
+        shell: bash
+        run: sudo chown -R "$(id -u):$(id -g)" build
+
       - name: Write playtest notes
         shell: bash
         run: |
@@ -241,6 +249,10 @@ jobs:
     name: Deploy Windows build to itch.io
     runs-on: ubuntu-latest
     needs: build-windows
+    if: github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
+    environment:
+      name: itch-production
+      url: https://theschlote.itch.io/friend-slop
     env:
       BUTLER_API_KEY: ${{ secrets.BUTLER_API_KEY }}
       BUTLER_API_KEY_PRESENT: ${{ secrets.BUTLER_API_KEY != '' }}


### PR DESCRIPTION
## Summary
- run the Unity workflow on pull requests and merge groups so branch protection can require CI
- gate itch deployment behind the `itch-production` environment and keep deploys limited to `main` and manual runs
- add a `CODEOWNERS` file to protect workflow and repository governance changes
- fix build artifact ownership before writing playtest notes

## Follow-up in GitHub settings
- edit the `Protect main` ruleset and add required checks after this PR's checks appear
- configure the `itch-production` environment reviewers and move `BUTLER_API_KEY` into the environment secret if you have not already