### PR TITLE
[codex] Harden multiplayer flows and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,4 +47,4 @@ When all three parts are installed, the rocket is assembled. Flying to the next 
 
 ## Playtest Builds
 
-GitHub Actions runs EditMode tests, builds the Windows player, and deploys it to itch.io with butler. See `docs/itch-cicd.md` for the one-time GitHub secret and itch.io page setup.
+GitHub Actions runs EditMode tests, a PlayMode smoke test, and the Windows build on pull requests, merge groups, and `main`. itch.io deployment only runs from `main` pushes or manual dispatches, and the `itch-production` environment can require approval before the butler push uses the deployment secret. See `docs/itch-cicd.md` for the current setup.

--- a/Space Game/Assets/Scripts/Loot/NetworkLootItem.cs
+++ b/Space Game/Assets/Scripts/Loot/NetworkLootItem.cs
@@ -12,6 +12,8 @@ namespace FriendSlop.Loot
     public class NetworkLootItem : NetworkBehaviour, IFriendSlopInteractable
     {
         private const ulong NoCarrier = ulong.MaxValue;
+        private const float DefaultInteractDistance = 3.2f;
+        private const float ServerPickupDistancePadding = 0.75f;
 
         [SerializeField] private string itemName = "Weird Junk";
         [SerializeField] private int value = 50;
@@ -144,14 +146,9 @@ namespace FriendSlop.Loot
         [Rpc(SendTo.Server, InvokePermission = RpcInvokePermission.Everyone)]
         public void RequestPickupServerRpc(RpcParams rpcParams = default)
         {
-            if (IsDeposited.Value || IsCarried.Value)
-            {
-                return;
-            }
-
             var senderId = rpcParams.Receive.SenderClientId;
             var player = NetworkFirstPersonController.FindByClientId(senderId);
-            if (player == null || player.HeldItem != null)
+            if (!CanServerPickup(player))
             {
                 return;
             }
@@ -160,6 +157,79 @@ namespace FriendSlop.Loot
             CarrierClientId.Value = senderId;
             ApplyPhysicsState();
             player.SetHeldItem(this);
+        }
+
+        private bool CanServerPickup(NetworkFirstPersonController player)
+        {
+            if (player == null || player.HeldItem != null || IsDeposited.Value || IsCarried.Value)
+            {
+                return false;
+            }
+
+            if (RoundManager.Instance == null || RoundManager.Instance.Phase.Value != RoundPhase.Active)
+            {
+                return false;
+            }
+
+            var origin = player.PlayerCamera != null
+                ? player.PlayerCamera.transform.position
+                : player.transform.position + player.transform.up * 0.75f;
+            var target = GetServerPickupTarget(origin);
+            var interactDistance = player.Interactor != null ? player.Interactor.InteractDistance : DefaultInteractDistance;
+            var maxDistance = interactDistance + ServerPickupDistancePadding;
+            if ((target - origin).sqrMagnitude > maxDistance * maxDistance)
+            {
+                return false;
+            }
+
+            return HasServerLineOfSight(player, origin, target);
+        }
+
+        private Vector3 GetServerPickupTarget(Vector3 origin)
+        {
+            if (colliders != null)
+            {
+                foreach (var itemCollider in colliders)
+                {
+                    if (itemCollider != null && itemCollider.enabled)
+                    {
+                        return itemCollider.ClosestPoint(origin);
+                    }
+                }
+            }
+
+            return transform.position;
+        }
+
+        private bool HasServerLineOfSight(NetworkFirstPersonController player, Vector3 origin, Vector3 target)
+        {
+            var direction = target - origin;
+            var distance = direction.magnitude;
+            if (distance <= 0.01f)
+            {
+                return true;
+            }
+
+            var hits = Physics.RaycastAll(origin, direction / distance, distance, ~0, QueryTriggerInteraction.Ignore);
+            System.Array.Sort(hits, (left, right) => left.distance.CompareTo(right.distance));
+
+            foreach (var hit in hits)
+            {
+                var hitCollider = hit.collider;
+                if (hitCollider == null)
+                {
+                    continue;
+                }
+
+                if (hitCollider.GetComponentInParent<NetworkFirstPersonController>() == player)
+                {
+                    continue;
+                }
+
+                return hitCollider.GetComponentInParent<NetworkLootItem>() == this;
+            }
+
+            return true;
         }
 
         [Rpc(SendTo.Server, InvokePermission = RpcInvokePermission.Everyone)]

--- a/Space Game/Assets/Scripts/Networking/NetworkSessionManager.cs
+++ b/Space Game/Assets/Scripts/Networking/NetworkSessionManager.cs
@@ -23,10 +23,12 @@ namespace FriendSlop.Networking
 
         private Lobby currentLobby;
         private float nextLobbyHeartbeat;
+        private bool heartbeatInFlight;
 
         public string LastJoinCode { get; private set; } = string.Empty;
         public string LastRelayRegion { get; private set; } = string.Empty;
         public string Status { get; private set; } = "Not connected.";
+        public bool IsBusy { get; private set; }
 
         private void Awake()
         {
@@ -39,25 +41,96 @@ namespace FriendSlop.Networking
             Instance = this;
         }
 
-        private async void Update()
+        private void Update()
         {
-            if (currentLobby == null || Time.realtimeSinceStartup < nextLobbyHeartbeat)
+            if (currentLobby == null || heartbeatInFlight || Time.realtimeSinceStartup < nextLobbyHeartbeat)
             {
                 return;
             }
 
             nextLobbyHeartbeat = Time.realtimeSinceStartup + 15f;
+            _ = SendLobbyHeartbeatAsync(currentLobby.Id);
+        }
+
+        private async Task SendLobbyHeartbeatAsync(string lobbyId)
+        {
+            heartbeatInFlight = true;
             try
             {
-                await LobbyService.Instance.SendHeartbeatPingAsync(currentLobby.Id);
+                await LobbyService.Instance.SendHeartbeatPingAsync(lobbyId);
             }
             catch (Exception exception)
             {
                 Debug.LogWarning($"Lobby heartbeat failed: {exception.Message}");
             }
+            finally
+            {
+                heartbeatInFlight = false;
+            }
         }
 
-        public async void HostOnline()
+        public void HostOnline()
+        {
+            _ = RunSessionOperationAsync(HostOnlineAsync);
+        }
+
+        public void JoinOnline(string joinCodeOrAddress)
+        {
+            _ = RunSessionOperationAsync(() => JoinOnlineAsync(joinCodeOrAddress));
+        }
+
+        public bool StartLocalHost()
+        {
+            if (IsBusy)
+            {
+                Status = "Please wait for the current session request to finish.";
+                return false;
+            }
+
+            return StartLocalHostInternal();
+        }
+
+        public bool StartLocalClient(string address)
+        {
+            if (IsBusy)
+            {
+                Status = "Please wait for the current session request to finish.";
+                return false;
+            }
+
+            return StartLocalClientInternal(address);
+        }
+
+        public void Shutdown()
+        {
+            _ = RunSessionOperationAsync(ShutdownAsync);
+        }
+
+        private async Task RunSessionOperationAsync(Func<Task> operation)
+        {
+            if (IsBusy)
+            {
+                Status = "Please wait for the current session request to finish.";
+                return;
+            }
+
+            IsBusy = true;
+            try
+            {
+                await operation();
+            }
+            catch (Exception exception)
+            {
+                Debug.LogError($"Unexpected session operation failure: {exception}");
+                Status = "Session request failed unexpectedly.";
+            }
+            finally
+            {
+                IsBusy = false;
+            }
+        }
+
+        private async Task HostOnlineAsync()
         {
             try
             {
@@ -66,14 +139,14 @@ namespace FriendSlop.Networking
             catch (Exception exception)
             {
                 Debug.LogWarning($"Relay host failed, falling back to local host: {exception.Message}");
-                if (StartLocalHost())
+                if (StartLocalHostInternal())
                 {
                     Status = $"Relay unavailable. Local host started on port {localPort}.";
                 }
             }
         }
 
-        public async void JoinOnline(string joinCodeOrAddress)
+        private async Task JoinOnlineAsync(string joinCodeOrAddress)
         {
             var target = JoinCodeUtility.NormalizeJoinTarget(joinCodeOrAddress);
             if (string.IsNullOrWhiteSpace(target))
@@ -84,7 +157,7 @@ namespace FriendSlop.Networking
 
             if (JoinCodeUtility.LooksLikeLanAddress(target))
             {
-                StartLocalClient(target);
+                StartLocalClientInternal(target);
                 return;
             }
 
@@ -107,7 +180,7 @@ namespace FriendSlop.Networking
             }
         }
 
-        public bool StartLocalHost()
+        private bool StartLocalHostInternal()
         {
             var networkManager = NetworkManager.Singleton;
             if (networkManager == null)
@@ -142,7 +215,7 @@ namespace FriendSlop.Networking
             return true;
         }
 
-        public bool StartLocalClient(string address)
+        private bool StartLocalClientInternal(string address)
         {
             var networkManager = NetworkManager.Singleton;
             if (networkManager == null)
@@ -182,7 +255,7 @@ namespace FriendSlop.Networking
             return true;
         }
 
-        public async void Shutdown()
+        private async Task ShutdownAsync()
         {
             await LeaveLobbyAsync();
 
@@ -334,6 +407,14 @@ namespace FriendSlop.Networking
         private void OnApplicationQuit()
         {
             _ = LeaveLobbyAsync();
+        }
+
+        private void OnDestroy()
+        {
+            if (Instance == this)
+            {
+                Instance = null;
+            }
         }
 
         private bool TryGetTransport(NetworkManager networkManager, out UnityTransport transport)

--- a/Space Game/Assets/Scripts/Player/PlayerInteractor.cs
+++ b/Space Game/Assets/Scripts/Player/PlayerInteractor.cs
@@ -18,6 +18,7 @@ namespace FriendSlop.Player
         private NetworkLootItem focusedLoot;
 
         public string CurrentPrompt { get; private set; }
+        public float InteractDistance => interactDistance;
 
         private void Awake()
         {

--- a/Space Game/Assets/Scripts/Round/RoundManager.cs
+++ b/Space Game/Assets/Scripts/Round/RoundManager.cs
@@ -40,6 +40,7 @@ namespace FriendSlop.Round
 
         public override void OnNetworkSpawn()
         {
+            Instance = this;
             if (NetworkManager != null)
             {
                 NetworkManager.OnClientDisconnectCallback += HandleClientDisconnect;
@@ -59,6 +60,21 @@ namespace FriendSlop.Round
             {
                 NetworkManager.OnClientDisconnectCallback -= HandleClientDisconnect;
             }
+
+            if (Instance == this)
+            {
+                Instance = null;
+            }
+        }
+
+        public override void OnDestroy()
+        {
+            if (Instance == this)
+            {
+                Instance = null;
+            }
+
+            base.OnDestroy();
         }
 
         private void Update()

--- a/Space Game/Assets/Scripts/UI/FriendSlopUI.cs
+++ b/Space Game/Assets/Scripts/UI/FriendSlopUI.cs
@@ -75,6 +75,14 @@ namespace FriendSlop.UI
             BuildUi();
         }
 
+        private void OnDestroy()
+        {
+            if (Instance == this)
+            {
+                Instance = null;
+            }
+        }
+
         private void Update()
         {
             if (Keyboard.current != null && Keyboard.current.tabKey.wasPressedThisFrame)
@@ -109,6 +117,7 @@ namespace FriendSlop.UI
             var round = RoundManager.Instance;
             var connected = networkManager != null && networkManager.IsListening;
             var isHost = networkManager != null && networkManager.IsHost;
+            var sessionBusy = session != null && session.IsBusy;
             var phase = round != null ? round.Phase.Value : RoundPhase.Lobby;
             var activeRound = connected && phase == RoundPhase.Active;
             var showMenu = !activeRound || menuPinned || Cursor.lockState != CursorLockMode.Locked;
@@ -138,6 +147,14 @@ namespace FriendSlop.UI
             restartButton.gameObject.SetActive(connected && isHost && (phase == RoundPhase.Success || phase == RoundPhase.Failed));
             shutdownButton.gameObject.SetActive(connected);
             lobbyQueueText.gameObject.SetActive(connected);
+            hostButton.interactable = !sessionBusy;
+            joinButton.interactable = !sessionBusy;
+            localHostButton.interactable = !sessionBusy;
+            localJoinButton.interactable = !sessionBusy;
+            startButton.interactable = !sessionBusy;
+            restartButton.interactable = !sessionBusy;
+            shutdownButton.interactable = !sessionBusy;
+            joinInput.interactable = !sessionBusy;
 
             LayoutMenu(connected, isHost, phase);
 
@@ -328,22 +345,94 @@ namespace FriendSlop.UI
             lobbyQueueText = CreateText("LobbyQueue", menuRoot.transform, string.Empty, 15, TextAnchor.UpperCenter, new Vector2(0.5f, 1f), new Vector2(0.5f, 1f), new Vector2(0f, -176f), new Vector2(440f, 82f));
 
             joinInput = CreateInput("JoinInput", menuRoot.transform, "Relay code or LAN IP", new Vector2(0f, 68f));
-            hostButton = CreateButton("Host Online", menuRoot.transform, Vector2.zero, () => NetworkSessionManager.Instance?.HostOnline());
-            joinButton = CreateButton("Join Code", menuRoot.transform, Vector2.zero, () => NetworkSessionManager.Instance?.JoinOnline(joinInput.text));
-            localHostButton = CreateButton("Host LAN", menuRoot.transform, Vector2.zero, () => NetworkSessionManager.Instance?.StartLocalHost());
-            localJoinButton = CreateButton("Join LAN", menuRoot.transform, Vector2.zero, () => NetworkSessionManager.Instance?.StartLocalClient(string.IsNullOrWhiteSpace(joinInput.text) ? "127.0.0.1" : joinInput.text));
-            startButton = CreateButton("Start Round", menuRoot.transform, Vector2.zero, () =>
-            {
-                RoundManager.Instance?.RequestStartRoundServerRpc();
-                LockGameplayCursor();
-            });
-            restartButton = CreateButton("Restart Round", menuRoot.transform, Vector2.zero, () =>
-            {
-                RoundManager.Instance?.RequestRestartRoundServerRpc();
-                LockGameplayCursor();
-            });
-            shutdownButton = CreateButton("Leave Session", menuRoot.transform, Vector2.zero, () => NetworkSessionManager.Instance?.Shutdown());
+            hostButton = CreateButton("Host Online", menuRoot.transform, Vector2.zero, HandleHostOnlineClick);
+            joinButton = CreateButton("Join Code", menuRoot.transform, Vector2.zero, HandleJoinOnlineClick);
+            localHostButton = CreateButton("Host LAN", menuRoot.transform, Vector2.zero, HandleHostLanClick);
+            localJoinButton = CreateButton("Join LAN", menuRoot.transform, Vector2.zero, HandleJoinLanClick);
+            startButton = CreateButton("Start Round", menuRoot.transform, Vector2.zero, HandleStartRoundClick);
+            restartButton = CreateButton("Restart Round", menuRoot.transform, Vector2.zero, HandleRestartRoundClick);
+            shutdownButton = CreateButton("Leave Session", menuRoot.transform, Vector2.zero, HandleLeaveSessionClick);
             quitButton = CreateButton("Quit", menuRoot.transform, Vector2.zero, QuitGame);
+        }
+
+        private void HandleHostOnlineClick()
+        {
+            var session = NetworkSessionManager.Instance;
+            if (session == null)
+            {
+                return;
+            }
+
+            session.HostOnline();
+        }
+
+        private void HandleJoinOnlineClick()
+        {
+            var session = NetworkSessionManager.Instance;
+            if (session == null)
+            {
+                return;
+            }
+
+            session.JoinOnline(joinInput != null ? joinInput.text : string.Empty);
+        }
+
+        private void HandleHostLanClick()
+        {
+            var session = NetworkSessionManager.Instance;
+            if (session == null)
+            {
+                return;
+            }
+
+            session.StartLocalHost();
+        }
+
+        private void HandleJoinLanClick()
+        {
+            var session = NetworkSessionManager.Instance;
+            if (session == null)
+            {
+                return;
+            }
+
+            var address = joinInput != null && !string.IsNullOrWhiteSpace(joinInput.text) ? joinInput.text : "127.0.0.1";
+            session.StartLocalClient(address);
+        }
+
+        private void HandleStartRoundClick()
+        {
+            var round = RoundManager.Instance;
+            if (round == null)
+            {
+                return;
+            }
+
+            round.RequestStartRoundServerRpc();
+            LockGameplayCursor();
+        }
+
+        private void HandleRestartRoundClick()
+        {
+            var round = RoundManager.Instance;
+            if (round == null)
+            {
+                return;
+            }
+
+            round.RequestRestartRoundServerRpc();
+            LockGameplayCursor();
+        }
+
+        private void HandleLeaveSessionClick()
+        {
+            var session = NetworkSessionManager.Instance;
+            if (session == null)
+            {
+                return;
+            }
+
+            session.Shutdown();
         }
 
         private GameObject CreatePanel(string name, Transform parent, Vector2 anchorMin, Vector2 anchorMax, Vector2 anchoredPosition, Vector2 size, Color color)

--- a/Space Game/CLAUDE.md
+++ b/Space Game/CLAUDE.md
@@ -1,73 +1,77 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+This file gives repository-specific guidance to coding agents working in this Unity project.
 
 ## Project Overview
 
-**Friend Slop** is a cooperative multiplayer space game built in Unity 6 (6000.3.4f1). Players explore a spherical planet, collect loot to meet a quota, assemble a rocket from three ship parts (Cockpit, Wings, Engine), and escape together via the launchpad.
+**Friend Slop** is a co-op multiplayer Unity 6 game prototype. Players explore a spherical planet, collect loot to meet a quota, assemble a rocket from three ship parts, and escape together from the launchpad.
 
-## Build & Run
+## Build And Run
 
-This is a Unity project — there are no CLI build scripts.
+There are no standalone CLI build scripts for local development.
 
-- **Engine**: Unity 6000.3.4f1
-- **Open the project** in Unity Hub, then open the main scene: `Assets/Scenes/FriendSlopPrototype.unity`
-- **Play**: Click Play in the Unity Editor
-- **Multiplayer testing**:
-  - Local: use "Local Host" button in-game, then join from another client via localhost
-  - Online: uses Unity Relay — host generates a join code, others enter it to connect
+- Engine: Unity `6000.3.4f1`
+- Open the Unity project folder: `Space Game`
+- Main scene: `Assets/Scenes/FriendSlopPrototype.unity`
+- Local multiplayer:
+  - LAN: use the in-game `Host LAN` and `Join LAN` buttons
+  - Online: use `Host Online` and `Join Code` through Unity Relay/Lobby
+- CI workflow: `.github/workflows/build-and-deploy-itch.yml`
+  - Pull requests and merge groups run EditMode tests, the PlayMode smoke test, and the Windows build
+  - itch.io deployment only runs from `main` or manual dispatches, through the protected `itch-production` environment
 
 ## Architecture
 
 ### Game Loop
 
-Phases are defined in `Scripts/Round/RoundPhase.cs`: `Lobby → Active → Success | Failed`.
+Phases are defined in `Assets/Scripts/Round/RoundPhase.cs`: `Lobby -> Active -> Success | Failed`.
 
-`RoundManager` (NetworkBehaviour) is the central orchestrator — it owns phase transitions, the countdown timer, quota tracking, ship part assembly state, and player boarding count. It is spawned server-side by `PrototypeNetworkBootstrapper` when the session starts.
+`RoundManager` is the central orchestrator. It owns phase transitions, the countdown timer, quota tracking, ship part assembly state, and player boarding count. It is spawned on the server by `PrototypeNetworkBootstrapper` when a session starts.
 
-### Spherical World & Physics
+### Spherical World And Physics
 
-`SphereWorld` (`Scripts/Core/`) defines the planet's center and radius. **All movement and physics must orient relative to the sphere surface** — gravity points inward toward `SphereWorld.Center`. The player controller, monsters, and physics objects all use this for orientation. Never assume world-up is Vector3.up.
+`SphereWorld` in `Assets/Scripts/Core/` defines the planet center and radius. All movement and physics must orient relative to the sphere surface. Gravity points inward toward `SphereWorld.Center`; do not assume `Vector3.up` is world up for gameplay code.
 
 ### Networking
 
-- `NetworkSessionManager` handles session creation/joining via Unity Relay + Lobbies (online) or direct IP (LAN). Falls back to localhost when Relay is unavailable.
-- `PrototypeNetworkBootstrapper` runs on the server: spawns `RoundManager`, loot items, and monsters on session start; cleans them up on stop.
-- All gameplay state flows through `ServerRpc` / `ClientRpc` on `NetworkBehaviour` subclasses. The server owns authoritative state; clients request changes via ServerRpc.
+- `NetworkSessionManager` handles Relay/Lobby hosting, join-code entry, and LAN fallback
+- `PrototypeNetworkBootstrapper` spawns the round manager, loot, and monsters when the server starts
+- `NetworkBehaviour` state is server authoritative; clients must request changes through RPCs instead of mutating gameplay state directly
 
 ### Player
 
-- `NetworkFirstPersonController` handles first-person camera, WASD movement aligned to spherical gravity, jump, and stamina-gated sprint.
-- `PlayerInteractor` manages the interaction loop: raycast focus detection, E to pick up, Q/right-click to drop/throw. A player can carry one item at a time; carrying reduces move speed via `carrySpeedMultiplier`.
+- `NetworkFirstPersonController` handles first-person movement, spherical alignment, jumping, sprinting, stamina, and local diagnostics
+- `PlayerInteractor` handles focus detection, pickup/drop/throw input, and carried item positioning
 
-### Loot & Submission
+### Loot And Submission
 
-- `NetworkLootItem` is the base for all collectibles. It tracks whether it is a generic loot item or a ship part (`ShipPartType`: None, Cockpit, Wings, Engine), and manages physics state when carried vs. dropped.
-- `DepositZone` accepts generic loot and adds its value toward the quota.
-- `LaunchpadZone` accepts ship parts (updating `RoundManager`'s assembly state) and counts players boarding for the launch condition.
-- `RocketAssemblyDisplay` updates visuals as parts are submitted.
+- `NetworkLootItem` is the base type for all collectible loot and ship parts
+- `DepositZone` accepts money loot and adds its value to the quota
+- `LaunchpadZone` accepts ship parts and tracks whether all players have boarded
+- `RocketAssemblyDisplay` updates rocket visuals as parts are submitted
 
-**Launch condition**: all three ship parts submitted AND all active players standing on the launchpad.
+Launch condition: all three ship parts submitted and all active players standing on the launchpad.
 
 ### UI
 
-`FriendSlopUI` handles both menus (host/join/start/restart) and the HUD (timer, quota bar, stamina bar, carried item). Menus block gameplay input; Tab toggles menu pin.
+`FriendSlopUI` builds the HUD and menu at runtime. Menus block gameplay input, `Tab` toggles the menu pin, `Esc` unlocks or re-locks the mouse, and `F3` toggles the debug panel.
 
 ## Namespace Map
 
 | Namespace | Location |
 |---|---|
-| `FriendSlop.Core` | `Scripts/Core/` |
-| `FriendSlop.Networking` | `Scripts/Networking/` |
-| `FriendSlop.Player` | `Scripts/Player/` |
-| `FriendSlop.Loot` | `Scripts/Loot/` |
-| `FriendSlop.Round` | `Scripts/Round/` |
-| `FriendSlop.Hazards` | `Scripts/Hazards/` |
-| `FriendSlop.UI` | `Scripts/UI/` |
-| `FriendSlop.Interaction` | `Scripts/` (interface) |
+| `FriendSlop.Core` | `Assets/Scripts/Core/` |
+| `FriendSlop.Networking` | `Assets/Scripts/Networking/` |
+| `FriendSlop.Player` | `Assets/Scripts/Player/` |
+| `FriendSlop.Loot` | `Assets/Scripts/Loot/` |
+| `FriendSlop.Round` | `Assets/Scripts/Round/` |
+| `FriendSlop.Hazards` | `Assets/Scripts/Hazards/` |
+| `FriendSlop.UI` | `Assets/Scripts/UI/` |
+| `FriendSlop.Interaction` | `Assets/Scripts/Interaction/` |
 
 ## Key Constraints
 
-- **Server authority**: State changes (item pickup, quota updates, phase transitions) must go through ServerRpc methods, not be applied client-side directly.
-- **Spherical gravity everywhere**: Any new movement, physics, or spawn logic needs to orient using `SphereWorld.Center`, not world-up.
-- **NetworkBehaviour lifecycle**: Objects with `NetworkBehaviour` must be spawned/despawned through `NetworkObject.Spawn()` / `Despawn()` on the server, not `Instantiate`/`Destroy` directly.
+- Server authority: quota changes, loot state, phase changes, and launch conditions must be validated on the server
+- Spherical gravity everywhere: new movement, spawn, and physics code should orient relative to `SphereWorld.Center`
+- Network lifecycle: networked objects must be spawned and despawned through `NetworkObject`
+- CI protections: do not weaken PR checks or deploy gating without also updating the repository docs and ruleset guidance in the root docs

--- a/docs/itch-cicd.md
+++ b/docs/itch-cicd.md
@@ -7,12 +7,12 @@ Workflow file: `.github/workflows/build-and-deploy-itch.yml`
 ## What It Does
 
 - Builds the Unity project in `Space Game` with Unity `6000.3.4f1`.
-- Runs EditMode tests and a PlayMode scene smoke test before building.
+- Runs EditMode tests and a PlayMode scene smoke test on pull requests, merge groups, and `main`.
 - Targets `StandaloneWindows64`.
 - Stamps each CI build as `0.1.<GitHub run number>`, which appears in-game and on itch.io.
 - Writes `PLAYTEST_NOTES.txt` into each build with the version, commit, workflow run, and recent commits.
 - Uploads the build as a GitHub Actions artifact.
-- Pushes the build to `theschlote/<game-slug>:windows` when `BUTLER_API_KEY` is configured.
+- Pushes the build to `theschlote/<game-slug>:windows` only for `main` pushes or manual workflow runs, and only when the `itch-production` environment is approved and `BUTLER_API_KEY` is configured there.
 
 The default itch.io game slug is `friend-slop`, so the default target is:
 
@@ -26,8 +26,10 @@ If the itch.io page uses a different slug, set a GitHub Actions repository varia
 
 1. Create an itch.io project page under `https://theschlote.itch.io/`.
 2. Use the page slug as the GitHub repository variable `ITCH_GAME`, unless the slug is `friend-slop`.
-3. Get a butler API key and add it as a GitHub Actions repository secret named `BUTLER_API_KEY`.
-4. Add Unity license secrets for GameCI.
+3. Create a GitHub Actions environment named `itch-production`.
+4. Add `BUTLER_API_KEY` as an environment secret on `itch-production`.
+5. Limit `itch-production` deployments to the `main` branch and add required reviewers if you want manual approval before deploys.
+6. Add Unity license secrets for GameCI at the repository level.
 
 For a Unity Personal license, add these GitHub Actions repository secrets:
 
@@ -53,31 +55,42 @@ In GitHub, open the repo and go to:
 Settings > Secrets and variables > Actions
 ```
 
-Use the `Secrets` tab for private values:
+Use the repository `Secrets` tab for Unity licensing:
 
 ```text
-BUTLER_API_KEY
 UNITY_LICENSE
 UNITY_SERIAL
 UNITY_EMAIL
 UNITY_PASSWORD
 ```
 
-Use the `Variables` tab for non-secret config:
+Use the repository `Variables` tab for non-secret config:
 
 ```text
 ITCH_GAME
+```
+
+Use the protected deployment environment for the butler token:
+
+```text
+Settings > Environments > itch-production
+```
+
+Add this environment secret there:
+
+```text
+BUTLER_API_KEY
 ```
 
 ## Running A Playtest Build
 
 After the account setup is done:
 
-1. Push to `main`, or open the GitHub `Actions` tab.
-2. Select `Build Windows and Deploy to itch.io`.
-3. Click `Run workflow`.
+1. Open a pull request to run EditMode tests, the PlayMode smoke test, and the Windows build without deploying.
+2. Merge to `main` to let the deploy job become eligible, or open the GitHub `Actions` tab and run the workflow manually.
+3. Approve the `itch-production` environment if required.
 
-If `BUTLER_API_KEY` is missing, the workflow still builds and uploads a GitHub artifact, but it will skip the itch.io deploy step.
+If `BUTLER_API_KEY` is missing from `itch-production`, the workflow still builds and uploads a GitHub artifact, but it will skip the itch.io deploy step.
 
 If the Unity license secrets are missing, the workflow stops before the Unity build and prints which secrets need to be added.
 


### PR DESCRIPTION
## Summary
- validate loot pickup requests on the server for round state, reach, and line of sight
- serialize online session operations and disable menu actions while requests are in flight
- clear Unity singleton instances on teardown and refresh docs for the protected deploy flow

## Why
The follow-up review found a few reliability and authority gaps after the CI hardening work:
- pickup RPCs trusted client reach and timing
- UI callbacks could hit destroyed singleton instances during teardown
- session host/join/shutdown flows were race-prone on repeated clicks
- the markdown docs still described the older deploy secret scope and workflow behavior

## Impact
- remote clients can no longer pick up loot from arbitrary distances or outside the active round
- repeated host/join/leave clicks are serialized instead of overlapping Relay/Lobby operations
- runtime menus are less likely to throw `MissingReferenceException` after scene or session teardown
- repo docs now match the `itch-production` environment and current CI workflow

## Validation
- `dotnet build "Space Game/FriendSlop.Runtime.csproj" -nologo`
- `dotnet build "Space Game/FriendSlop.PlayModeTests.csproj" -nologo`
- `dotnet build "Space Game/FriendSlop.EditModeTests.csproj" -nologo`

## Notes
- unrelated local edits in the scene and material files were intentionally left out of this change set