### PR TITLE
[codex] Fix multiplayer joins and CI warnings

### DIFF
--- a/.github/workflows/build-and-deploy-itch.yml
+++ b/.github/workflows/build-and-deploy-itch.yml
@@ -15,7 +15,6 @@ permissions:
   checks: write
 
 env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   UNITY_PROJECT_PATH: Space Game
   UNITY_VERSION: 6000.3.4f1
   BUILD_TARGET: StandaloneWindows64
@@ -49,13 +48,13 @@ jobs:
           fi
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           lfs: true
 
       - name: Cache Unity Library
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{ env.UNITY_PROJECT_PATH }}/Library
           key: Library-FriendSlop-${{ runner.os }}-EditMode-${{ hashFiles('Space Game/Packages/manifest.json', 'Space Game/Packages/packages-lock.json', 'Space Game/ProjectSettings/**', 'Space Game/Assets/**') }}
@@ -79,7 +78,7 @@ jobs:
 
       - name: Upload EditMode test results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: FriendSlop-EditMode-Test-Results-${{ github.run_number }}
           path: test-results
@@ -111,13 +110,13 @@ jobs:
           fi
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           lfs: true
 
       - name: Cache Unity Library
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{ env.UNITY_PROJECT_PATH }}/Library
           key: Library-FriendSlop-${{ runner.os }}-PlayMode-${{ hashFiles('Space Game/Packages/manifest.json', 'Space Game/Packages/packages-lock.json', 'Space Game/ProjectSettings/**', 'Space Game/Assets/**') }}
@@ -142,7 +141,7 @@ jobs:
 
       - name: Upload PlayMode test results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: FriendSlop-PlayMode-Test-Results-${{ github.run_number }}
           path: playmode-test-results
@@ -178,13 +177,13 @@ jobs:
           fi
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           lfs: true
 
       - name: Cache Unity Library
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{ env.UNITY_PROJECT_PATH }}/Library
           key: Library-FriendSlop-${{ runner.os }}-${{ env.BUILD_TARGET }}-${{ hashFiles('Space Game/Packages/manifest.json', 'Space Game/Packages/packages-lock.json', 'Space Game/ProjectSettings/**', 'Space Game/Assets/**') }}
@@ -240,7 +239,7 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload Windows build artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: FriendSlop-Windows-${{ github.run_number }}
           path: build/${{ env.BUILD_TARGET }}
@@ -268,7 +267,7 @@ jobs:
 
       - name: Download Windows build artifact
         if: env.BUTLER_API_KEY_PRESENT == 'true'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: FriendSlop-Windows-${{ github.run_number }}
           path: build/${{ env.BUILD_TARGET }}

--- a/Space Game/Assets/Materials/GlowCube.mat
+++ b/Space Game/Assets/Materials/GlowCube.mat
@@ -11,7 +11,8 @@ Material:
   m_Shader: {fileID: 4800000, guid: 933532a4fcc9baf4fa0491de14d08ed7, type: 3}
   m_Parent: {fileID: 0}
   m_ModifiedSerializedProperties: 0
-  m_ValidKeywords: []
+  m_ValidKeywords:
+  - _EMISSION
   m_InvalidKeywords: []
   m_LightmapFlags: 4
   m_EnableInstancingVariants: 0

--- a/Space Game/Assets/Scenes/FriendSlopPrototype.unity
+++ b/Space Game/Assets/Scenes/FriendSlopPrototype.unity
@@ -959,7 +959,7 @@ MonoBehaviour:
     EnableTimeResync: 0
     TimeResyncInterval: 30
     EnsureNetworkVariableLengthSafety: 0
-    EnableSceneManagement: 0
+    EnableSceneManagement: 1
     ForceSamePrefabs: 1
     RecycleNetworkIds: 1
     NetworkIdRecycleDelay: 120

--- a/Space Game/Assets/Scripts/Editor/FriendSlopSceneBuilder.cs
+++ b/Space Game/Assets/Scripts/Editor/FriendSlopSceneBuilder.cs
@@ -528,7 +528,7 @@ namespace FriendSlop.Editor
             networkManager.NetworkConfig.Prefabs.NetworkPrefabsLists.Clear();
             networkManager.NetworkConfig.Prefabs.NetworkPrefabsLists.Add(networkPrefabsList);
             networkManager.NetworkConfig.ConnectionApproval = false;
-            networkManager.NetworkConfig.EnableSceneManagement = false;
+            networkManager.NetworkConfig.EnableSceneManagement = true;
             networkObject.AddComponent<NetworkSessionManager>();
         }
 

--- a/Space Game/Assets/Scripts/Player/NetworkFirstPersonController.cs
+++ b/Space Game/Assets/Scripts/Player/NetworkFirstPersonController.cs
@@ -180,8 +180,10 @@ namespace FriendSlop.Player
                 }
 
                 var roundManager = RoundManager.Instance;
-                if (roundManager != null && (roundManager.Phase.Value == RoundPhase.Active || roundManager.Phase.Value == RoundPhase.Loading))
+                if (roundManager != null)
                     roundManager.ServerPlaceNewPlayer(this);
+                else
+                    StartCoroutine(ServerPlaceWhenRoundManagerReady());
             }
 
             if (IsOwner)
@@ -519,24 +521,69 @@ namespace FriendSlop.Player
                 return;
             }
 
-            transform.SetPositionAndRotation(position, rotation);
-            TeleportClientRpc(position, rotation);
+            var safePosition = GetSurfaceSafeTeleportPosition(position);
+            var safeRotation = GetSurfaceSafeTeleportRotation(safePosition, rotation);
+            ApplyTeleport(safePosition, safeRotation);
+            TeleportClientRpc(safePosition, safeRotation);
         }
 
         [ClientRpc]
         private void TeleportClientRpc(Vector3 position, Quaternion rotation)
         {
-            if (!IsOwner)
-            {
-                transform.SetPositionAndRotation(position, rotation);
-                return;
-            }
+            ApplyTeleport(position, rotation);
+        }
 
-            characterController.enabled = false;
+        private IEnumerator ServerPlaceWhenRoundManagerReady()
+        {
+            for (var frame = 0; frame < 120; frame++)
+            {
+                if (!IsSpawned)
+                    yield break;
+
+                var roundManager = RoundManager.Instance;
+                if (roundManager != null)
+                {
+                    roundManager.ServerPlaceNewPlayer(this);
+                    yield break;
+                }
+
+                yield return null;
+            }
+        }
+
+        private void ApplyTeleport(Vector3 position, Quaternion rotation)
+        {
+            var controllerWasEnabled = characterController != null && characterController.enabled;
+            if (controllerWasEnabled)
+                characterController.enabled = false;
+
             transform.SetPositionAndRotation(position, rotation);
-            characterController.enabled = true;
+
+            if (controllerWasEnabled)
+                characterController.enabled = true;
+
             radialSpeed = 0f;
             knockbackVelocity = Vector3.zero;
+        }
+
+        private static Vector3 GetSurfaceSafeTeleportPosition(Vector3 position)
+        {
+            var world = SphereWorld.GetClosest(position);
+            if (world == null)
+                return position;
+
+            var up = world.GetUp(position);
+            return world.GetSurfacePoint(up, 0.08f);
+        }
+
+        private static Quaternion GetSurfaceSafeTeleportRotation(Vector3 position, Quaternion requestedRotation)
+        {
+            var world = SphereWorld.GetClosest(position);
+            if (world == null)
+                return requestedRotation;
+
+            var up = world.GetUp(position);
+            return world.GetSurfaceRotation(up, requestedRotation * Vector3.forward);
         }
 
         [ClientRpc]

--- a/Space Game/ProjectSettings/ProjectSettings.asset
+++ b/Space Game/ProjectSettings/ProjectSettings.asset
@@ -929,7 +929,7 @@ PlayerSettings:
   qualitySettingsNames: []
   projectName: Space Game
   organizationId: theschlote
-  cloudEnabled: 0
+  cloudEnabled: 1
   legacyClampBlendShapeWeights: 0
   hmiLoadingImage: {fileID: 0}
   platformRequiresReadableAssets: 0

--- a/Space Game/ProjectSettings/UnityConnectSettings.asset
+++ b/Space Game/ProjectSettings/UnityConnectSettings.asset
@@ -4,7 +4,7 @@
 UnityConnectSettings:
   m_ObjectHideFlags: 0
   serializedVersion: 1
-  m_Enabled: 0
+  m_Enabled: 1
   m_TestMode: 0
   m_EventOldUrl: https://api.uca.cloud.unity3d.com/v1/events
   m_EventUrl: https://cdp.cloud.unity3d.com/v1/events


### PR DESCRIPTION
## Summary

Fixes the multiplayer join path that produced missing Netcode object hash errors and player fall-throughs, reduces CI warning noise from outdated GitHub-owned action versions, and normalizes a Unity material that was being rewritten on every editor open.

## Changes

- Enables Netcode scene management in the prototype scene and scene builder so in-scene NetworkObjects are synchronized to joining clients.
- Hardens networked player placement and teleports by waiting for the round manager when needed and snapping teleport targets to the nearest planet surface.
- Updates GitHub-owned workflow actions to Node 24-compatible majors and removes the forced Node 24 action runtime flag.
- Enables the already-linked Unity Cloud project settings so ServicesCore sees the project as linked.
- Restores the `_EMISSION` shader keyword on `GlowCube.mat` to match its non-black emission color and stop Unity from auto-rewriting the material.

## Notes

GameCI's latest upstream v4 actions still declare Node 20 and no v5 tag is currently available, so those warnings may require a future GameCI release or a fork/replacement if GitHub starts enforcing them independently.

## Validation

- `git diff --cached --check`
- `git diff --check -- "Space Game/Assets/Materials/GlowCube.mat"`
- `dotnet restore "Space Game/FriendSlop.Runtime.csproj"`
- `dotnet build "Space Game/FriendSlop.Runtime.csproj" --no-restore`
- `dotnet restore "Space Game/FriendSlop.Editor.csproj"`
- `dotnet build "Space Game/FriendSlop.Editor.csproj" --no-restore`

Unity PlayMode tests were not run locally because this machine does not have Unity `6000.3.4f1` installed.