### PR TITLE
[Bugs/CI/Architecture] Apply zip handoff fixes

### DIFF
--- a/.github/actions/check-unity-license/action.yml
+++ b/.github/actions/check-unity-license/action.yml
@@ -1,0 +1,23 @@
+name: Check Unity License Secrets
+description: Validates that Unity license secrets are configured before running Unity jobs
+
+runs:
+  using: composite
+  steps:
+    - name: Validate Unity license secrets
+      shell: bash
+      env:
+        UNITY_LICENSE: ${{ env.UNITY_LICENSE }}
+        UNITY_SERIAL: ${{ env.UNITY_SERIAL }}
+        UNITY_EMAIL: ${{ env.UNITY_EMAIL }}
+        UNITY_PASSWORD: ${{ env.UNITY_PASSWORD }}
+      run: |
+        if [[ -z "$UNITY_EMAIL" || -z "$UNITY_PASSWORD" ]]; then
+          echo "::error::Set UNITY_EMAIL and UNITY_PASSWORD in GitHub Actions secrets."
+          exit 1
+        fi
+
+        if [[ -z "$UNITY_LICENSE" && -z "$UNITY_SERIAL" ]]; then
+          echo "::error::Set UNITY_LICENSE for a Personal license, or UNITY_SERIAL for a Pro/Plus license."
+          exit 1
+        fi

--- a/.github/workflows/build-and-deploy-itch.yml
+++ b/.github/workflows/build-and-deploy-itch.yml
@@ -51,29 +51,19 @@ jobs:
     timeout-minutes: 25
 
     steps:
-      - name: Check Unity license secrets
-        shell: bash
-        env:
-          UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
-          UNITY_SERIAL: ${{ secrets.UNITY_SERIAL }}
-          UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
-          UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
-        run: |
-          if [[ -z "$UNITY_EMAIL" || -z "$UNITY_PASSWORD" ]]; then
-            echo "::error::Set UNITY_EMAIL and UNITY_PASSWORD in GitHub Actions secrets."
-            exit 1
-          fi
-
-          if [[ -z "$UNITY_LICENSE" && -z "$UNITY_SERIAL" ]]; then
-            echo "::error::Set UNITY_LICENSE for a Personal license, or UNITY_SERIAL for a Pro/Plus license."
-            exit 1
-          fi
-
       - name: Checkout
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
           lfs: true
+
+      - name: Check Unity license secrets
+        uses: ./.github/actions/check-unity-license
+        env:
+          UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
+          UNITY_SERIAL: ${{ secrets.UNITY_SERIAL }}
+          UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
+          UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
 
       - name: Cache Unity Library
         uses: actions/cache@v5
@@ -110,33 +100,23 @@ jobs:
   playmode-tests:
     name: Run PlayMode smoke tests
     runs-on: ubuntu-22.04
-    needs: editmode-tests
+    needs: validate-unity-version
     timeout-minutes: 25
 
     steps:
-      - name: Check Unity license secrets
-        shell: bash
-        env:
-          UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
-          UNITY_SERIAL: ${{ secrets.UNITY_SERIAL }}
-          UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
-          UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
-        run: |
-          if [[ -z "$UNITY_EMAIL" || -z "$UNITY_PASSWORD" ]]; then
-            echo "::error::Set UNITY_EMAIL and UNITY_PASSWORD in GitHub Actions secrets."
-            exit 1
-          fi
-
-          if [[ -z "$UNITY_LICENSE" && -z "$UNITY_SERIAL" ]]; then
-            echo "::error::Set UNITY_LICENSE for a Personal license, or UNITY_SERIAL for a Pro/Plus license."
-            exit 1
-          fi
-
       - name: Checkout
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
           lfs: true
+
+      - name: Check Unity license secrets
+        uses: ./.github/actions/check-unity-license
+        env:
+          UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
+          UNITY_SERIAL: ${{ secrets.UNITY_SERIAL }}
+          UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
+          UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
 
       - name: Cache Unity Library
         uses: actions/cache@v5
@@ -182,29 +162,19 @@ jobs:
       build-version: ${{ steps.unity-build.outputs.buildVersion }}
 
     steps:
-      - name: Check Unity license secrets
-        shell: bash
-        env:
-          UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
-          UNITY_SERIAL: ${{ secrets.UNITY_SERIAL }}
-          UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
-          UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
-        run: |
-          if [[ -z "$UNITY_EMAIL" || -z "$UNITY_PASSWORD" ]]; then
-            echo "::error::Set UNITY_EMAIL and UNITY_PASSWORD in GitHub Actions secrets."
-            exit 1
-          fi
-
-          if [[ -z "$UNITY_LICENSE" && -z "$UNITY_SERIAL" ]]; then
-            echo "::error::Set UNITY_LICENSE for a Personal license, or UNITY_SERIAL for a Pro/Plus license."
-            exit 1
-          fi
-
       - name: Checkout
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
           lfs: true
+
+      - name: Check Unity license secrets
+        uses: ./.github/actions/check-unity-license
+        env:
+          UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
+          UNITY_SERIAL: ${{ secrets.UNITY_SERIAL }}
+          UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
+          UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
 
       - name: Cache Unity Library
         uses: actions/cache@v5

--- a/.github/workflows/build-and-deploy-itch.yml
+++ b/.github/workflows/build-and-deploy-itch.yml
@@ -151,12 +151,67 @@ jobs:
           if-no-files-found: warn
           retention-days: 14
 
+  validate-scenes:
+    name: Validate planet scenes
+    runs-on: ubuntu-22.04
+    needs: validate-unity-version
+    timeout-minutes: 25
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          lfs: true
+
+      - name: Check Unity license secrets
+        uses: ./.github/actions/check-unity-license
+        env:
+          UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
+          UNITY_SERIAL: ${{ secrets.UNITY_SERIAL }}
+          UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
+          UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
+
+      - name: Cache Unity Library
+        uses: actions/cache@v5
+        with:
+          path: ${{ env.UNITY_PROJECT_PATH }}/Library
+          key: Library-FriendSlop-${{ runner.os }}-SceneValidation-${{ hashFiles('Space Game/Packages/manifest.json', 'Space Game/Packages/packages-lock.json', 'Space Game/ProjectSettings/**', 'Space Game/Assets/**') }}
+          restore-keys: |
+            Library-FriendSlop-${{ runner.os }}-SceneValidation-
+            Library-FriendSlop-${{ runner.os }}-
+
+      - name: Run planet scene validator
+        uses: game-ci/unity-test-runner@v4
+        env:
+          UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
+          UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
+          UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
+          UNITY_SERIAL: ${{ secrets.UNITY_SERIAL }}
+        with:
+          projectPath: ${{ env.UNITY_PROJECT_PATH }}
+          unityVersion: ${{ env.UNITY_VERSION }}
+          testMode: EditMode
+          testFilter: FriendSlop.Tests.EditMode.PlanetSceneValidatorTests
+          artifactsPath: scene-validation-results
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload planet scene validation results
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: FriendSlop-Scene-Validation-Results-${{ github.run_number }}
+          path: scene-validation-results
+          if-no-files-found: warn
+          retention-days: 14
+
   build-windows:
     name: Build Windows player
     runs-on: ubuntu-22.04
     needs:
       - editmode-tests
       - playmode-tests
+      - validate-scenes
     timeout-minutes: 60
     outputs:
       build-version: ${{ steps.unity-build.outputs.buildVersion }}

--- a/.github/workflows/build-and-deploy-itch.yml
+++ b/.github/workflows/build-and-deploy-itch.yml
@@ -21,7 +21,6 @@ concurrency:
 env:
   UNITY_PROJECT_PATH: Space Game
   UNITY_VERSION: 6000.3.4f1
-  BUILD_TARGET: StandaloneWindows64
   BUILD_NAME: FriendSlop
   BUILD_VERSION: 0.1.${{ github.run_number }}
   # GameCI v4 actions still declare Node 20 as of this workflow revision.
@@ -205,16 +204,27 @@ jobs:
           if-no-files-found: warn
           retention-days: 14
 
-  build-windows:
-    name: Build Windows player
+  build-player:
+    name: Build ${{ matrix.label }} player
     runs-on: ubuntu-22.04
     needs:
       - editmode-tests
       - playmode-tests
       - validate-scenes
     timeout-minutes: 60
-    outputs:
-      build-version: ${{ steps.unity-build.outputs.buildVersion }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - targetPlatform: StandaloneWindows64
+            itchChannel: windows
+            label: Windows
+          - targetPlatform: StandaloneLinux64
+            itchChannel: linux
+            label: Linux
+          - targetPlatform: StandaloneOSX
+            itchChannel: mac
+            label: macOS
 
     steps:
       - name: Checkout
@@ -235,12 +245,12 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ${{ env.UNITY_PROJECT_PATH }}/Library
-          key: Library-FriendSlop-${{ runner.os }}-${{ env.BUILD_TARGET }}-${{ hashFiles('Space Game/Packages/manifest.json', 'Space Game/Packages/packages-lock.json', 'Space Game/ProjectSettings/**', 'Space Game/Assets/**') }}
+          key: Library-FriendSlop-${{ runner.os }}-${{ matrix.targetPlatform }}-${{ hashFiles('Space Game/Packages/manifest.json', 'Space Game/Packages/packages-lock.json', 'Space Game/ProjectSettings/**', 'Space Game/Assets/**') }}
           restore-keys: |
-            Library-FriendSlop-${{ runner.os }}-${{ env.BUILD_TARGET }}-
+            Library-FriendSlop-${{ runner.os }}-${{ matrix.targetPlatform }}-
             Library-FriendSlop-${{ runner.os }}-
 
-      - name: Build Windows player
+      - name: Build ${{ matrix.label }} player
         id: unity-build
         uses: game-ci/unity-builder@v4
         env:
@@ -251,7 +261,7 @@ jobs:
         with:
           projectPath: ${{ env.UNITY_PROJECT_PATH }}
           unityVersion: ${{ env.UNITY_VERSION }}
-          targetPlatform: ${{ env.BUILD_TARGET }}
+          targetPlatform: ${{ matrix.targetPlatform }}
           buildName: ${{ env.BUILD_NAME }}
           buildsPath: build
           versioning: Custom
@@ -259,22 +269,28 @@ jobs:
 
       - name: Fix build output ownership
         shell: bash
-        run: sudo chown -R "$(id -u):$(id -g)" build
+        run: sudo chown -R "$(id -u):$(id -g)" "build/${TARGET_PLATFORM}"
+        env:
+          TARGET_PLATFORM: ${{ matrix.targetPlatform }}
 
       - name: Write playtest notes
         shell: bash
+        env:
+          TARGET_PLATFORM: ${{ matrix.targetPlatform }}
+          ITCH_CHANNEL: ${{ matrix.itchChannel }}
+          PLATFORM_LABEL: ${{ matrix.label }}
         run: |
-          output_dir="build/${BUILD_TARGET}"
+          output_dir="build/${TARGET_PLATFORM}"
           notes_path="${output_dir}/PLAYTEST_NOTES.txt"
           release_notes_path="${output_dir}/RELEASE_NOTES.md"
           mkdir -p "$output_dir"
 
           {
-            echo "# Friend Slop Retrieval ${BUILD_VERSION}"
+            echo "# Friend Slop Retrieval ${BUILD_VERSION} (${PLATFORM_LABEL})"
             echo
             echo "- Commit: \`${GITHUB_SHA}\`"
             echo "- Build: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
-            echo "- Itch channel: ${ITCH_USER}/${ITCH_GAME}:windows"
+            echo "- Itch channel: ${ITCH_USER}/${ITCH_GAME}:${ITCH_CHANNEL}"
             echo
             if [[ -f RELEASE_NOTES.md ]]; then
               echo "## Curated Release Notes"
@@ -289,10 +305,10 @@ jobs:
           } > "$release_notes_path"
 
           {
-            echo "Friend Slop Retrieval ${BUILD_VERSION}"
+            echo "Friend Slop Retrieval ${BUILD_VERSION} (${PLATFORM_LABEL})"
             echo "Commit: ${GITHUB_SHA}"
             echo "Build: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
-            echo "Itch channel: ${ITCH_USER}/${ITCH_GAME}:windows"
+            echo "Itch channel: ${ITCH_USER}/${ITCH_GAME}:${ITCH_CHANNEL}"
             echo
             if [[ -f RELEASE_NOTES.md ]]; then
               echo "Curated release notes:"
@@ -306,20 +322,33 @@ jobs:
 
           cat "$release_notes_path" >> "$GITHUB_STEP_SUMMARY"
 
-      - name: Upload Windows build artifact
+      - name: Upload ${{ matrix.label }} build artifact
         uses: actions/upload-artifact@v7
         with:
-          name: FriendSlop-Windows-${{ github.run_number }}
-          path: build/${{ env.BUILD_TARGET }}
+          name: FriendSlop-${{ matrix.itchChannel }}-${{ github.run_number }}
+          path: build/${{ matrix.targetPlatform }}
           if-no-files-found: error
           retention-days: 14
 
   deploy-itch:
-    name: Deploy Windows build to itch.io
+    name: Deploy ${{ matrix.label }} build to itch.io
     runs-on: ubuntu-22.04
-    needs: build-windows
+    needs: build-player
     if: github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
     timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - targetPlatform: StandaloneWindows64
+            itchChannel: windows
+            label: Windows
+          - targetPlatform: StandaloneLinux64
+            itchChannel: linux
+            label: Linux
+          - targetPlatform: StandaloneOSX
+            itchChannel: mac
+            label: macOS
     environment:
       name: itch-production
       url: https://theschlote.itch.io/friend-slop
@@ -332,19 +361,21 @@ jobs:
         if: env.BUTLER_API_KEY_PRESENT != 'true'
         run: |
           echo "BUTLER_API_KEY is not set, so the itch.io deploy step was skipped."
-          echo "The Windows build artifact is still available on this workflow run."
+          echo "The ${PLATFORM_LABEL} build artifact is still available on this workflow run."
           {
             echo "### itch.io deploy skipped"
             echo
-            echo "BUTLER_API_KEY is not configured. The Windows build artifact is still available on this run."
+            echo "BUTLER_API_KEY is not configured. The ${PLATFORM_LABEL} build artifact is still available on this run."
           } >> "$GITHUB_STEP_SUMMARY"
+        env:
+          PLATFORM_LABEL: ${{ matrix.label }}
 
-      - name: Download Windows build artifact
+      - name: Download ${{ matrix.label }} build artifact
         if: env.BUTLER_API_KEY_PRESENT == 'true'
         uses: actions/download-artifact@v8
         with:
-          name: FriendSlop-Windows-${{ github.run_number }}
-          path: build/${{ env.BUILD_TARGET }}
+          name: FriendSlop-${{ matrix.itchChannel }}-${{ github.run_number }}
+          path: build/${{ matrix.targetPlatform }}
 
       - name: Install butler
         if: env.BUTLER_API_KEY_PRESENT == 'true'
@@ -358,17 +389,17 @@ jobs:
       - name: Push build to itch.io
         if: env.BUTLER_API_KEY_PRESENT == 'true'
         shell: bash
+        env:
+          TARGET_PLATFORM: ${{ matrix.targetPlatform }}
+          ITCH_CHANNEL: ${{ matrix.itchChannel }}
         run: |
-          user_version="${{ needs.build-windows.outputs.build-version }}"
-          if [[ -z "$user_version" ]]; then
-            user_version="${GITHUB_SHA::7}"
-          fi
+          user_version="${BUILD_VERSION}"
 
-          ./butler/butler push "build/${BUILD_TARGET}" "${ITCH_USER}/${ITCH_GAME}:windows" --userversion "$user_version"
+          ./butler/butler push "build/${TARGET_PLATFORM}" "${ITCH_USER}/${ITCH_GAME}:${ITCH_CHANNEL}" --userversion "$user_version"
           {
             echo "### Deployed to itch.io"
             echo
             echo "- Page: https://${ITCH_USER}.itch.io/${ITCH_GAME}"
-            echo "- Channel: ${ITCH_USER}/${ITCH_GAME}:windows"
+            echo "- Channel: ${ITCH_USER}/${ITCH_GAME}:${ITCH_CHANNEL}"
             echo "- Version: ${user_version}"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/Space Game/Assets/Prefabs/RoundManager.prefab
+++ b/Space Game/Assets/Prefabs/RoundManager.prefab
@@ -11,6 +11,7 @@ GameObject:
   - component: {fileID: 1366301870837280682}
   - component: {fileID: 2241022140542481033}
   - component: {fileID: 5631540053391249862}
+  - component: {fileID: 688656829663541873}
   m_Layer: 0
   m_Name: RoundManager
   m_TagString: Untagged
@@ -74,8 +75,11 @@ MonoBehaviour:
   quota: 0
   roundLengthSeconds: 0
   playerSpawnPoints: []
+  shipSpawnPoints: []
+  returnToShipOnRoundEnd: 1
   planetCatalog: {fileID: 11400000, guid: b633b88ecc9715d4497101cdf30fe8af, type: 2}
   startingPlanet: {fileID: 11400000, guid: e23f03a4d5f48ff4b8fc68c33031b581, type: 2}
+  planetSceneOrchestrator: {fileID: 688656829663541873}
   defaultObjective: {fileID: 11400000, guid: b325c8ff756ce0e478e8f571eca1f060, type: 2}
   Phase:
     UpdateTraits:
@@ -147,3 +151,20 @@ MonoBehaviour:
       MinSecondsBetweenUpdates: 0
       MaxSecondsBetweenUpdates: 0
     m_InternalValue: -1
+  NextPlanetChoiceIndices:
+    UpdateTraits:
+      MinSecondsBetweenUpdates: 0
+      MaxSecondsBetweenUpdates: 0
+--- !u!114 &688656829663541873
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3469322735182761814}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ff57778c35b84c7d9a0c54f104eecbcb, type: 3}
+  m_Name:
+  m_EditorClassIdentifier: FriendSlop.Runtime::FriendSlop.Round.PlanetSceneOrchestrator
+  ShowTopMostFoldoutHeaderGroup: 1

--- a/Space Game/Assets/Scripts/Core/CarrySurfaceUtility.cs
+++ b/Space Game/Assets/Scripts/Core/CarrySurfaceUtility.cs
@@ -1,0 +1,27 @@
+using UnityEngine;
+
+namespace FriendSlop.Core
+{
+    public static class CarrySurfaceUtility
+    {
+        private const float MinimumSurfaceClearance = 0.1f;
+
+        public static Vector3 ClampTargetAboveSurface(Vector3 targetPosition, float minimumSurfaceClearance = MinimumSurfaceClearance)
+        {
+            if (FlatGravityVolume.TryGetContaining(targetPosition, out _))
+            {
+                return targetPosition;
+            }
+
+            var world = SphereWorld.GetClosest(targetPosition);
+            if (world == null)
+            {
+                return targetPosition;
+            }
+
+            return world.GetSurfaceDistance(targetPosition) < -minimumSurfaceClearance
+                ? world.GetSurfacePoint(world.GetUp(targetPosition), minimumSurfaceClearance)
+                : targetPosition;
+        }
+    }
+}

--- a/Space Game/Assets/Scripts/Core/CarrySurfaceUtility.cs.meta
+++ b/Space Game/Assets/Scripts/Core/CarrySurfaceUtility.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e58a983fed554eb99a379b2e2cefd79b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Space Game/Assets/Scripts/Core/GameplayInputState.cs
+++ b/Space Game/Assets/Scripts/Core/GameplayInputState.cs
@@ -11,18 +11,37 @@ namespace FriendSlop.Core
     // blocked by default, which is the safe answer for headless tests.
     public static class GameplayInputState
     {
-        private static Func<bool> _provider = () => false;
+        private static readonly Func<bool> DefaultProvider = () => false;
+        private static Func<bool> _provider = DefaultProvider;
+        private static object _providerOwner;
 
         public static bool IsBlocked => _provider();
 
         public static void RegisterBlockProvider(Func<bool> provider)
         {
-            _provider = provider ?? (() => false);
+            RegisterBlockProvider(provider?.Target, provider);
+        }
+
+        public static void RegisterBlockProvider(object owner, Func<bool> provider)
+        {
+            _providerOwner = owner;
+            _provider = provider ?? DefaultProvider;
         }
 
         public static void ClearBlockProvider()
         {
-            _provider = () => false;
+            _providerOwner = null;
+            _provider = DefaultProvider;
+        }
+
+        public static void ClearBlockProvider(object owner)
+        {
+            if (_providerOwner != owner)
+            {
+                return;
+            }
+
+            ClearBlockProvider();
         }
     }
 }

--- a/Space Game/Assets/Scripts/Editor/Builders/FriendSlopSceneBuilder.RoundManagerPrefab.cs
+++ b/Space Game/Assets/Scripts/Editor/Builders/FriendSlopSceneBuilder.RoundManagerPrefab.cs
@@ -14,20 +14,52 @@ namespace FriendSlop.Editor
             var existing = AssetDatabase.LoadAssetAtPath<GameObject>(RoundManagerPrefabPath);
             if (existing != null)
             {
-                return existing.GetComponent<RoundManager>();
+                return EnsureRoundManagerPrefabComponents();
             }
 
             var root = new GameObject("Round Manager");
             root.AddComponent<NetworkObject>();
             var round = root.AddComponent<RoundManager>();
+            var orchestrator = root.AddComponent<PlanetSceneOrchestrator>();
             var serializedRound = new SerializedObject(round);
             serializedRound.FindProperty("quota").intValue = 0;
             serializedRound.FindProperty("roundLengthSeconds").floatValue = 0f;
+            serializedRound.FindProperty("planetSceneOrchestrator").objectReferenceValue = orchestrator;
             serializedRound.ApplyModifiedPropertiesWithoutUndo();
 
             var prefab = PrefabUtility.SaveAsPrefabAsset(root, RoundManagerPrefabPath);
             Object.DestroyImmediate(root);
             return prefab.GetComponent<RoundManager>();
+        }
+
+        private static RoundManager EnsureRoundManagerPrefabComponents()
+        {
+            var root = PrefabUtility.LoadPrefabContents(RoundManagerPrefabPath);
+            try
+            {
+                if (root.GetComponent<NetworkObject>() == null)
+                    root.AddComponent<NetworkObject>();
+
+                var round = root.GetComponent<RoundManager>();
+                if (round == null)
+                    round = root.AddComponent<RoundManager>();
+
+                var orchestrator = root.GetComponent<PlanetSceneOrchestrator>();
+                if (orchestrator == null)
+                    orchestrator = root.AddComponent<PlanetSceneOrchestrator>();
+
+                var serializedRound = new SerializedObject(round);
+                serializedRound.FindProperty("planetSceneOrchestrator").objectReferenceValue = orchestrator;
+                serializedRound.ApplyModifiedPropertiesWithoutUndo();
+
+                PrefabUtility.SaveAsPrefabAsset(root, RoundManagerPrefabPath);
+            }
+            finally
+            {
+                PrefabUtility.UnloadPrefabContents(root);
+            }
+
+            return AssetDatabase.LoadAssetAtPath<GameObject>(RoundManagerPrefabPath)?.GetComponent<RoundManager>();
         }
     }
 }

--- a/Space Game/Assets/Scripts/Editor/FriendSlopMultiPlanetBuilder.cs
+++ b/Space Game/Assets/Scripts/Editor/FriendSlopMultiPlanetBuilder.cs
@@ -478,15 +478,30 @@ namespace FriendSlop.Editor
                 Debug.LogWarning($"RoundManager prefab not found at {RoundManagerPrefabPath}; skipping catalog wiring.");
                 return;
             }
-            var round = prefab.GetComponent<RoundManager>();
-            if (round == null) return;
 
-            var so = new SerializedObject(round);
-            so.FindProperty("planetCatalog").objectReferenceValue = catalog;
-            so.FindProperty("startingPlanet").objectReferenceValue = startingPlanet;
-            so.FindProperty("defaultObjective").objectReferenceValue = defaultObjective;
-            so.ApplyModifiedPropertiesWithoutUndo();
-            EditorUtility.SetDirty(prefab);
+            var root = PrefabUtility.LoadPrefabContents(RoundManagerPrefabPath);
+            try
+            {
+                var round = root.GetComponent<RoundManager>();
+                if (round == null) return;
+
+                var orchestrator = root.GetComponent<PlanetSceneOrchestrator>();
+                if (orchestrator == null)
+                    orchestrator = root.AddComponent<PlanetSceneOrchestrator>();
+
+                var so = new SerializedObject(round);
+                so.FindProperty("planetCatalog").objectReferenceValue = catalog;
+                so.FindProperty("startingPlanet").objectReferenceValue = startingPlanet;
+                so.FindProperty("planetSceneOrchestrator").objectReferenceValue = orchestrator;
+                so.FindProperty("defaultObjective").objectReferenceValue = defaultObjective;
+                so.ApplyModifiedPropertiesWithoutUndo();
+
+                PrefabUtility.SaveAsPrefabAsset(root, RoundManagerPrefabPath);
+            }
+            finally
+            {
+                PrefabUtility.UnloadPrefabContents(root);
+            }
         }
 
         private static void PlaceOnSurface(SphereWorld world, Transform target, Vector3 normal, float heightOffset)

--- a/Space Game/Assets/Scripts/Editor/FriendSlopSceneBuilder.cs
+++ b/Space Game/Assets/Scripts/Editor/FriendSlopSceneBuilder.cs
@@ -142,7 +142,7 @@ namespace FriendSlop.Editor
             var materials = CreateMaterials();
             var monsterPrefab = AssetDatabase.LoadAssetAtPath<RoamingMonster>(MonsterPrefabPath) ?? BuildMonsterPrefab(materials);
             var playerPrefab = AssetDatabase.LoadAssetAtPath<GameObject>(PlayerPrefabPath) ?? BuildPlayerPrefab(materials);
-            var roundManagerPrefab = AssetDatabase.LoadAssetAtPath<GameObject>(RoundManagerPrefabPath);
+            var roundManagerPrefab = BuildRoundManagerPrefab()?.gameObject;
             var lootPrefabs = LoadLootPrefabs();
             BuildNetworkPrefabsList(playerPrefab, roundManagerPrefab, monsterPrefab.gameObject, lootPrefabs);
             EnsureBootstrapperLootReferences(lootPrefabs);
@@ -169,7 +169,7 @@ namespace FriendSlop.Editor
             var materials = CreateMaterials();
             var monsterPrefab = BuildMonsterPrefab(materials);
             var playerPrefab = BuildPlayerPrefab(materials);
-            var roundManagerPrefab = AssetDatabase.LoadAssetAtPath<GameObject>(RoundManagerPrefabPath);
+            var roundManagerPrefab = BuildRoundManagerPrefab()?.gameObject;
             var lootPrefabs = LoadLootPrefabs();
             BuildNetworkPrefabsList(playerPrefab, roundManagerPrefab, monsterPrefab.gameObject, lootPrefabs);
             EnsureBootstrapperLootReferences(lootPrefabs);

--- a/Space Game/Assets/Scripts/Editor/FriendSlopSceneBuilder.cs
+++ b/Space Game/Assets/Scripts/Editor/FriendSlopSceneBuilder.cs
@@ -592,6 +592,8 @@ namespace FriendSlop.Editor
             var serializedBootstrapper = new SerializedObject(bootstrapper);
 
             serializedBootstrapper.FindProperty("roundManagerPrefab").objectReferenceValue = roundManagerPrefab;
+            serializedBootstrapper.FindProperty("sceneTransitionService").objectReferenceValue =
+                Object.FindFirstObjectByType<NetworkSceneTransitionService>();
             AssignObjectArray(serializedBootstrapper.FindProperty("playerSpawnPoints"), playerSpawns);
             AssignObjectArray(serializedBootstrapper.FindProperty("shipSpawnPoints"), shipSpawns);
             AssignObjectArray(serializedBootstrapper.FindProperty("lootPrefabs"), lootPrefabs);
@@ -618,7 +620,11 @@ namespace FriendSlop.Editor
         private static void CreateRuntimeUi()
         {
             var ui = new GameObject("Friend Slop Runtime UI");
-            ui.AddComponent<FriendSlopUI>();
+            var friendSlopUi = ui.AddComponent<FriendSlopUI>();
+            var serializedUi = new SerializedObject(friendSlopUi);
+            serializedUi.FindProperty("sessionManager").objectReferenceValue =
+                Object.FindFirstObjectByType<NetworkSessionManager>();
+            serializedUi.ApplyModifiedPropertiesWithoutUndo();
         }
 
         private static GameObject CreateSurfaceProp(string name, Transform parent, SphereWorld world, PrimitiveType shape, Vector3 surfaceNormal, Vector3 forwardHint, float heightOffset, Vector3 scale, Material material)

--- a/Space Game/Assets/Scripts/Editor/PlanetSceneValidator.cs
+++ b/Space Game/Assets/Scripts/Editor/PlanetSceneValidator.cs
@@ -1,0 +1,330 @@
+using System.Collections.Generic;
+using System.IO;
+using FriendSlop.Core;
+using FriendSlop.Round;
+using FriendSlop.SceneManagement;
+using UnityEditor;
+using UnityEditor.SceneManagement;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+
+namespace FriendSlop.Editor
+{
+    public static class PlanetSceneValidator
+    {
+        private const string BootstrapScenePath = "Assets/Scenes/FriendSlopPrototype.unity";
+
+        [MenuItem("Tools/Friend Slop/Validate Planet Scenes")]
+        public static void ValidateFromMenu()
+        {
+            if (TryValidate(out var failures))
+            {
+                Debug.Log("Friend Slop planet scene validation passed.");
+                return;
+            }
+
+            Debug.LogError(FormatFailureMessage(failures));
+        }
+
+        public static void Validate()
+        {
+            if (TryValidate(out var failures))
+            {
+                Debug.Log("Friend Slop planet scene validation passed.");
+                if (Application.isBatchMode)
+                    EditorApplication.Exit(0);
+                return;
+            }
+
+            var message = FormatFailureMessage(failures);
+            Debug.LogError(message);
+            if (Application.isBatchMode)
+                EditorApplication.Exit(1);
+            throw new System.InvalidOperationException(message);
+        }
+
+        public static bool TryValidate(out List<string> failures)
+        {
+            failures = new List<string>();
+            ValidateCatalogPlanetScenesInBuildSettings(failures);
+            ValidateSceneCatalogPlanetEntriesInBuildSettings(failures);
+            ValidateCatalogPlanetScenesRoundReady(failures);
+            ValidateBootstrapShipTeleporter(failures);
+            return failures.Count == 0;
+        }
+
+        public static void ValidateCatalogPlanetScenesInBuildSettings(List<string> failures)
+        {
+            if (failures == null) throw new System.ArgumentNullException(nameof(failures));
+
+            var buildScenes = LoadBuildSettingsScenePaths();
+
+            foreach (var catalog in LoadAllAssets<PlanetCatalog>())
+            {
+                if (catalog == null || catalog.AllPlanets == null) continue;
+
+                for (var i = 0; i < catalog.AllPlanets.Count; i++)
+                {
+                    var planet = catalog.AllPlanets[i];
+                    if (planet == null || !planet.HasPlanetScene) continue;
+
+                    var scenePath = planet.PlanetScene.ScenePath;
+                    var label = $"{catalog.name} -> {planet.name} -> {planet.PlanetScene.name}";
+                    ValidateScenePathInBuildSettings(buildScenes, scenePath, label, failures);
+                }
+            }
+        }
+
+        public static void ValidateSceneCatalogPlanetEntriesInBuildSettings(List<string> failures)
+        {
+            if (failures == null) throw new System.ArgumentNullException(nameof(failures));
+
+            var buildScenes = LoadBuildSettingsScenePaths();
+
+            foreach (var catalog in LoadAllAssets<GameSceneCatalog>())
+            {
+                if (catalog == null || catalog.AllScenes == null) continue;
+
+                for (var i = 0; i < catalog.AllScenes.Count; i++)
+                {
+                    var def = catalog.AllScenes[i];
+                    if (def == null || def.Role != GameSceneRole.Planet) continue;
+                    if (!def.IsConfigured) continue;
+
+                    ValidateScenePathInBuildSettings(buildScenes, def.ScenePath, $"{catalog.name} -> {def.name}", failures);
+                }
+            }
+        }
+
+        public static void ValidateCatalogPlanetScenesRoundReady(List<string> failures)
+        {
+            if (failures == null) throw new System.ArgumentNullException(nameof(failures));
+
+            foreach (var catalog in LoadAllAssets<PlanetCatalog>())
+            {
+                if (catalog == null || catalog.AllPlanets == null) continue;
+
+                for (var i = 0; i < catalog.AllPlanets.Count; i++)
+                {
+                    var planet = catalog.AllPlanets[i];
+                    if (planet == null || !planet.HasPlanetScene) continue;
+
+                    var scenePath = GameScenePathUtility.NormalizePath(planet.PlanetScene.ScenePath);
+                    var label = $"{catalog.name} -> {planet.name} -> {planet.PlanetScene.name}";
+                    if (!File.Exists(scenePath))
+                    {
+                        failures.Add($"{label}: scene file does not exist at '{scenePath}'.");
+                        continue;
+                    }
+
+                    WithScene(scenePath, scene =>
+                    {
+                        var environments = GetComponentsInScene<PlanetEnvironment>(scene);
+                        var environment = FindCompatibleEnvironment(environments, planet);
+
+                        if (environment == null)
+                        {
+                            failures.Add($"{label}: no compatible PlanetEnvironment was found.");
+                            return;
+                        }
+
+                        if (environment.LaunchpadZone == null)
+                            failures.Add($"{label}: PlanetEnvironment '{environment.name}' has no LaunchpadZone assigned.");
+
+                        if (!HasAnyLiveTransform(environment.PlayerSpawnPoints))
+                            failures.Add($"{label}: PlanetEnvironment '{environment.name}' has no live player spawn points.");
+
+                        if (ResolveSphereWorld(environment) == null)
+                            failures.Add($"{label}: PlanetEnvironment '{environment.name}' has no SphereWorld assigned or discoverable.");
+
+                        if (!HasTeleporterToShip(scene))
+                            failures.Add($"{label}: scene has no TeleporterPad targeting Ship.");
+                    });
+                }
+            }
+        }
+
+        public static void ValidateBootstrapShipTeleporter(List<string> failures)
+        {
+            if (failures == null) throw new System.ArgumentNullException(nameof(failures));
+
+            if (!File.Exists(BootstrapScenePath))
+            {
+                failures.Add($"Bootstrap scene does not exist at '{BootstrapScenePath}'.");
+                return;
+            }
+
+            WithScene(BootstrapScenePath, scene =>
+            {
+                if (!HasTeleporterToActivePlanet(scene))
+                    failures.Add("The bootstrap ship scene should include a TeleporterPad targeting ActivePlanet.");
+            });
+        }
+
+        private static void ValidateScenePathInBuildSettings(
+            IReadOnlyDictionary<string, bool> buildScenes,
+            string scenePath,
+            string label,
+            List<string> failures)
+        {
+            scenePath = GameScenePathUtility.NormalizePath(scenePath);
+            if (!File.Exists(scenePath))
+            {
+                failures.Add($"{label}: scene file does not exist at '{scenePath}'.");
+                return;
+            }
+
+            if (!buildScenes.TryGetValue(scenePath, out var enabled))
+            {
+                failures.Add($"{label}: scene '{scenePath}' is not in EditorBuildSettings.");
+                return;
+            }
+
+            if (!enabled)
+                failures.Add($"{label}: scene '{scenePath}' is in EditorBuildSettings but disabled.");
+        }
+
+        private static Dictionary<string, bool> LoadBuildSettingsScenePaths()
+        {
+            var result = new Dictionary<string, bool>(System.StringComparer.OrdinalIgnoreCase);
+            var scenes = EditorBuildSettings.scenes;
+            for (var i = 0; i < scenes.Length; i++)
+            {
+                var entry = scenes[i];
+                if (entry == null || string.IsNullOrEmpty(entry.path)) continue;
+                var normalized = GameScenePathUtility.NormalizePath(entry.path);
+                result[normalized] = entry.enabled;
+            }
+            return result;
+        }
+
+        private static IEnumerable<T> LoadAllAssets<T>() where T : UnityEngine.Object
+        {
+            var guids = AssetDatabase.FindAssets("t:" + typeof(T).Name);
+            foreach (var guid in guids)
+            {
+                var path = AssetDatabase.GUIDToAssetPath(guid);
+                var asset = AssetDatabase.LoadAssetAtPath<T>(path);
+                if (asset != null) yield return asset;
+            }
+        }
+
+        private static void WithScene(string scenePath, System.Action<Scene> inspect)
+        {
+            var setup = EditorSceneManager.GetSceneManagerSetup();
+            Scene scene = default;
+            try
+            {
+                scene = EditorSceneManager.OpenScene(scenePath, OpenSceneMode.Additive);
+                inspect(scene);
+            }
+            finally
+            {
+                if (!TryRestoreSceneSetup(setup))
+                {
+                    if (scene.IsValid() && scene.isLoaded)
+                        EditorSceneManager.CloseScene(scene, true);
+                    EditorSceneManager.NewScene(NewSceneSetup.EmptyScene, NewSceneMode.Single);
+                }
+            }
+        }
+
+        private static bool TryRestoreSceneSetup(SceneSetup[] setup)
+        {
+            if (setup == null || setup.Length == 0)
+                return false;
+
+            try
+            {
+                EditorSceneManager.RestoreSceneManagerSetup(setup);
+                return true;
+            }
+            catch (System.ArgumentException)
+            {
+                return false;
+            }
+        }
+
+        private static T[] GetComponentsInScene<T>(Scene scene) where T : Component
+        {
+            var results = new List<T>();
+            var roots = scene.GetRootGameObjects();
+            for (var i = 0; i < roots.Length; i++)
+            {
+                results.AddRange(roots[i].GetComponentsInChildren<T>(true));
+            }
+            return results.ToArray();
+        }
+
+        private static PlanetEnvironment FindCompatibleEnvironment(PlanetEnvironment[] environments, PlanetDefinition planet)
+        {
+            if (environments == null || planet == null) return null;
+
+            for (var i = 0; i < environments.Length; i++)
+            {
+                var env = environments[i];
+                if (env != null && env.Planet == planet)
+                    return env;
+            }
+
+            for (var i = 0; i < environments.Length; i++)
+            {
+                var env = environments[i];
+                if (env != null && env.Planet != null && env.Planet.Tier == planet.Tier)
+                    return env;
+            }
+
+            return null;
+        }
+
+        private static bool HasAnyLiveTransform(Transform[] transforms)
+        {
+            if (transforms == null) return false;
+            for (var i = 0; i < transforms.Length; i++)
+            {
+                if (transforms[i] != null)
+                    return true;
+            }
+            return false;
+        }
+
+        private static SphereWorld ResolveSphereWorld(PlanetEnvironment environment)
+        {
+            if (environment == null) return null;
+            if (environment.SphereWorld != null) return environment.SphereWorld;
+
+            var world = environment.GetComponentInChildren<SphereWorld>(true);
+            if (world != null) return world;
+
+            var contentRoot = environment.ContentRoot;
+            return contentRoot != null ? contentRoot.GetComponentInChildren<SphereWorld>(true) : null;
+        }
+
+        private static bool HasTeleporterToShip(Scene scene)
+        {
+            var pads = GetComponentsInScene<TeleporterPad>(scene);
+            for (var i = 0; i < pads.Length; i++)
+            {
+                if (pads[i] != null && pads[i].Destination == TeleporterTarget.Ship)
+                    return true;
+            }
+            return false;
+        }
+
+        private static bool HasTeleporterToActivePlanet(Scene scene)
+        {
+            var pads = GetComponentsInScene<TeleporterPad>(scene);
+            for (var i = 0; i < pads.Length; i++)
+            {
+                if (pads[i] != null && pads[i].Destination == TeleporterTarget.ActivePlanet)
+                    return true;
+            }
+            return false;
+        }
+
+        private static string FormatFailureMessage(List<string> failures)
+        {
+            return "Friend Slop planet scene validation failed:\n  - " + string.Join("\n  - ", failures);
+        }
+    }
+}

--- a/Space Game/Assets/Scripts/Editor/PlanetSceneValidator.cs.meta
+++ b/Space Game/Assets/Scripts/Editor/PlanetSceneValidator.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 81f1c1ad6e9449f09d4770c8141bcbb8

--- a/Space Game/Assets/Scripts/Loot/NetworkLootItem.CarrySync.cs
+++ b/Space Game/Assets/Scripts/Loot/NetworkLootItem.CarrySync.cs
@@ -1,0 +1,32 @@
+using FriendSlop.Core;
+using FriendSlop.Player;
+using Unity.Netcode;
+using UnityEngine;
+
+namespace FriendSlop.Loot
+{
+    public partial class NetworkLootItem
+    {
+        [Rpc(SendTo.Server, InvokePermission = RpcInvokePermission.Everyone)]
+        public void MoveCarriedServerRpc(Vector3 targetPosition, Quaternion targetRotation, RpcParams rpcParams = default)
+        {
+            if (!IsHeldBy(rpcParams.Receive.SenderClientId) || IsDeposited.Value)
+            {
+                return;
+            }
+
+            var player = NetworkFirstPersonController.FindByClientId(rpcParams.Receive.SenderClientId);
+            if (player != null && Vector3.SqrMagnitude(targetPosition - player.transform.position) > 16f)
+            {
+                targetPosition = player.transform.position + player.transform.forward * carryDistance + player.transform.up * 1.2f;
+            }
+
+            targetPosition = CarrySurfaceUtility.ClampTargetAboveSurface(targetPosition);
+
+            body.position = targetPosition;
+            body.rotation = targetRotation;
+            ClearDynamicVelocity();
+            transform.SetPositionAndRotation(targetPosition, targetRotation);
+        }
+    }
+}

--- a/Space Game/Assets/Scripts/Loot/NetworkLootItem.CarrySync.cs.meta
+++ b/Space Game/Assets/Scripts/Loot/NetworkLootItem.CarrySync.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 022aca281e6d48669a70c6ac6981e2c9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Space Game/Assets/Scripts/Loot/NetworkLootItem.cs
+++ b/Space Game/Assets/Scripts/Loot/NetworkLootItem.cs
@@ -10,7 +10,7 @@ namespace FriendSlop.Loot
 {
     [RequireComponent(typeof(NetworkObject))]
     [RequireComponent(typeof(Rigidbody))]
-    public class NetworkLootItem : NetworkBehaviour, IFriendSlopInteractable
+    public partial class NetworkLootItem : NetworkBehaviour, IFriendSlopInteractable
     {
         private const ulong NoCarrier = ulong.MaxValue;
         private const float ServerPickupMaxDistance = 4.25f;
@@ -47,6 +47,7 @@ namespace FriendSlop.Loot
         public NetworkVariable<ulong> CarrierClientId = new(NoCarrier);
         public NetworkVariable<bool> IsDeposited = new(false);
 
+        private NetworkFirstPersonController _cachedCarrier;
         private NetworkFirstPersonController subscribedCarrier;
 
         public string ItemName => itemName;
@@ -110,6 +111,7 @@ namespace FriendSlop.Loot
             IsDeposited.OnValueChanged -= OnDepositedChanged;
             SlotIndex.OnValueChanged -= OnSlotIndexChanged;
             UnsubscribeFromCarrierActiveSlot();
+            _cachedCarrier = null;
         }
 
         public bool CanInteract(NetworkFirstPersonController player)
@@ -307,26 +309,6 @@ namespace FriendSlop.Loot
                 : serverDirection;
         }
 
-        [Rpc(SendTo.Server, InvokePermission = RpcInvokePermission.Everyone)]
-        public void MoveCarriedServerRpc(Vector3 targetPosition, Quaternion targetRotation, RpcParams rpcParams = default)
-        {
-            if (!IsHeldBy(rpcParams.Receive.SenderClientId) || IsDeposited.Value)
-            {
-                return;
-            }
-
-            var player = NetworkFirstPersonController.FindByClientId(rpcParams.Receive.SenderClientId);
-            if (player != null && Vector3.SqrMagnitude(targetPosition - player.transform.position) > 16f)
-            {
-                targetPosition = player.transform.position + player.transform.forward * carryDistance + player.transform.up * 1.2f;
-            }
-
-            body.position = targetPosition;
-            body.rotation = targetRotation;
-            ClearDynamicVelocity();
-            transform.SetPositionAndRotation(targetPosition, targetRotation);
-        }
-
         // Max legitimate throw impulse = throwImpulse(8) * chargeThrowMultiplier(3.5) ≈ 28.
         // Clamp at 30 to reject obviously spoofed magnitudes while allowing real throws.
         private const float MaxDropImpulseMagnitude = 30f;
@@ -400,8 +382,7 @@ namespace FriendSlop.Loot
             var round = RoundManager.Instance;
             if (round == null || round.Phase.Value != RoundPhase.Active) return false;
 
-            var carrier = NetworkFirstPersonController.FindByClientId(senderId);
-            if (carrier == null) return false;
+            if (!TryGetCachedCarrier(senderId, out var carrier)) return false;
 
             surface = ItemDepositSurface.FindFor(carrier, this);
             return surface != null;
@@ -438,7 +419,7 @@ namespace FriendSlop.Loot
                 return;
             }
 
-            var carrier = NetworkFirstPersonController.FindByClientId(CarrierClientId.Value);
+            TryGetCachedCarrier(CarrierClientId.Value, out var carrier);
             carrier?.ClearHeldItem(this);
             ClearServerDepositHold();
 
@@ -460,7 +441,7 @@ namespace FriendSlop.Loot
                 return;
             }
 
-            var carrier = NetworkFirstPersonController.FindByClientId(CarrierClientId.Value);
+            TryGetCachedCarrier(CarrierClientId.Value, out var carrier);
             carrier?.ClearHeldItem(this);
             ClearServerDepositHold();
 
@@ -488,7 +469,7 @@ namespace FriendSlop.Loot
                 return;
             }
 
-            var carrier = NetworkFirstPersonController.FindByClientId(CarrierClientId.Value);
+            TryGetCachedCarrier(CarrierClientId.Value, out var carrier);
             carrier?.ClearHeldItem(this);
             ClearServerDepositHold();
 
@@ -544,18 +525,22 @@ namespace FriendSlop.Loot
 
         private void OnCarrierChanged(ulong previousCarrier, ulong currentCarrier)
         {
-            var previousPlayer = NetworkFirstPersonController.FindByClientId(previousCarrier);
+            var previousPlayer = previousCarrier != NoCarrier
+                ? NetworkFirstPersonController.FindByClientId(previousCarrier)
+                : null;
             previousPlayer?.ClearHeldItem(this);
 
             UnsubscribeFromCarrierActiveSlot();
 
-            var currentPlayer = NetworkFirstPersonController.FindByClientId(currentCarrier);
-            currentPlayer?.SetHeldItem(this);
+            _cachedCarrier = currentCarrier != NoCarrier
+                ? NetworkFirstPersonController.FindByClientId(currentCarrier)
+                : null;
+            _cachedCarrier?.SetHeldItem(this);
 
-            if (currentPlayer != null)
+            if (_cachedCarrier != null)
             {
-                subscribedCarrier = currentPlayer;
-                currentPlayer.ActiveInventorySlot.OnValueChanged += OnCarrierActiveSlotChanged;
+                subscribedCarrier = _cachedCarrier;
+                _cachedCarrier.ActiveInventorySlot.OnValueChanged += OnCarrierActiveSlotChanged;
             }
 
             ApplyVisibilityState();
@@ -613,8 +598,7 @@ namespace FriendSlop.Loot
             ValidateServerDepositHold();
             if (!IsCarried.Value || IsDeposited.Value) return;
 
-            var carrier = NetworkFirstPersonController.FindByClientId(CarrierClientId.Value);
-            if (carrier == null) return;
+            if (!TryGetCachedCarrier(CarrierClientId.Value, out var carrier)) return;
             if (SlotIndex.Value == carrier.ActiveInventorySlot.Value) return;
 
             var stowedPos = carrier.transform.position + carrier.transform.up * 0.6f;
@@ -627,8 +611,7 @@ namespace FriendSlop.Loot
             get
             {
                 if (!IsCarried.Value || IsDeposited.Value) return false;
-                var carrier = NetworkFirstPersonController.FindByClientId(CarrierClientId.Value);
-                if (carrier == null) return false;
+                if (!TryGetCachedCarrier(CarrierClientId.Value, out var carrier)) return false;
                 return SlotIndex.Value == carrier.ActiveInventorySlot.Value;
             }
         }
@@ -679,8 +662,8 @@ namespace FriendSlop.Loot
             {
                 // Stowed inventory items (carried but not in the active slot) are hidden so
                 // only the item in the player's "hand" is visible.
-                var carrier = NetworkFirstPersonController.FindByClientId(CarrierClientId.Value);
-                if (carrier != null && SlotIndex.Value != carrier.ActiveInventorySlot.Value)
+                if (TryGetCachedCarrier(CarrierClientId.Value, out var carrier)
+                    && SlotIndex.Value != carrier.ActiveInventorySlot.Value)
                     visible = false;
             }
 
@@ -703,6 +686,18 @@ namespace FriendSlop.Loot
                     itemCollider.enabled = shouldEnable;
                 }
             }
+        }
+
+        private bool TryGetCachedCarrier(ulong clientId, out NetworkFirstPersonController carrier)
+        {
+            carrier = _cachedCarrier;
+            if (carrier == null || carrier.OwnerClientId != clientId)
+            {
+                carrier = null;
+                return false;
+            }
+
+            return true;
         }
     }
 }

--- a/Space Game/Assets/Scripts/Networking/NetworkSessionManager.Lifecycle.cs
+++ b/Space Game/Assets/Scripts/Networking/NetworkSessionManager.Lifecycle.cs
@@ -9,13 +9,6 @@ namespace FriendSlop.Networking
     {
         private void Awake()
         {
-            if (Instance != null && Instance != this)
-            {
-                Destroy(gameObject);
-                return;
-            }
-
-            Instance = this;
             TaskScheduler.UnobservedTaskException += HandleUnobservedTaskException;
             TrySubscribeToNetworkManager();
         }
@@ -60,11 +53,6 @@ namespace FriendSlop.Networking
         {
             TaskScheduler.UnobservedTaskException -= HandleUnobservedTaskException;
             UnsubscribeFromNetworkManager();
-
-            if (Instance == this)
-            {
-                Instance = null;
-            }
         }
 
         private void HandleUnobservedTaskException(object sender, UnobservedTaskExceptionEventArgs args)

--- a/Space Game/Assets/Scripts/Networking/NetworkSessionManager.Lifecycle.cs
+++ b/Space Game/Assets/Scripts/Networking/NetworkSessionManager.Lifecycle.cs
@@ -1,0 +1,76 @@
+using System;
+using System.Threading.Tasks;
+using Unity.Services.Lobbies;
+using UnityEngine;
+
+namespace FriendSlop.Networking
+{
+    public partial class NetworkSessionManager
+    {
+        private void Awake()
+        {
+            if (Instance != null && Instance != this)
+            {
+                Destroy(gameObject);
+                return;
+            }
+
+            Instance = this;
+            TaskScheduler.UnobservedTaskException += HandleUnobservedTaskException;
+            TrySubscribeToNetworkManager();
+        }
+
+        private void OnEnable()
+        {
+            TrySubscribeToNetworkManager();
+        }
+
+        private async void Update()
+        {
+            TrySubscribeToNetworkManager();
+            CheckPendingConnectionTimeout();
+
+            if (currentLobby == null || Time.realtimeSinceStartup < nextLobbyHeartbeat)
+            {
+                return;
+            }
+
+            nextLobbyHeartbeat = Time.realtimeSinceStartup + 15f;
+            try
+            {
+                await WithServiceTimeout(LobbyService.Instance.SendHeartbeatPingAsync(currentLobby.Id), "Lobby heartbeat");
+            }
+            catch (Exception exception)
+            {
+                Debug.LogWarning($"Lobby heartbeat failed: {exception.Message}");
+            }
+        }
+
+        private void OnDisable()
+        {
+            UnsubscribeFromNetworkManager();
+        }
+
+        private void OnApplicationQuit()
+        {
+            _ = LeaveLobbyAsync();
+        }
+
+        private void OnDestroy()
+        {
+            TaskScheduler.UnobservedTaskException -= HandleUnobservedTaskException;
+            UnsubscribeFromNetworkManager();
+
+            if (Instance == this)
+            {
+                Instance = null;
+            }
+        }
+
+        private void HandleUnobservedTaskException(object sender, UnobservedTaskExceptionEventArgs args)
+        {
+            Debug.LogError($"Unobserved session task exception: {args.Exception}");
+            args.SetObserved();
+        }
+    }
+}

--- a/Space Game/Assets/Scripts/Networking/NetworkSessionManager.Lifecycle.cs.meta
+++ b/Space Game/Assets/Scripts/Networking/NetworkSessionManager.Lifecycle.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0669a0c18d6b419e9918309065d995b3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Space Game/Assets/Scripts/Networking/NetworkSessionManager.Online.cs
+++ b/Space Game/Assets/Scripts/Networking/NetworkSessionManager.Online.cs
@@ -1,0 +1,114 @@
+using System;
+using UnityEngine;
+
+namespace FriendSlop.Networking
+{
+    public partial class NetworkSessionManager
+    {
+        public async void HostOnline()
+        {
+            var operationId = 0;
+
+            try
+            {
+                if (!TryBeginSessionOperation("Starting online host...", out operationId))
+                {
+                    return;
+                }
+
+                await HostRelayAsync(operationId);
+            }
+            catch (Exception exception) when (operationId != 0 && !IsSessionOperationCancelled(operationId))
+            {
+                Debug.LogWarning($"Relay host failed, falling back to local host: {exception.Message}");
+                sessionOperationInProgress = false;
+                if (StartLocalHost())
+                {
+                    Status = $"Relay unavailable. Local host started on port {localPort}.";
+                }
+            }
+            catch (Exception exception)
+            {
+                if (operationId != 0 && IsSessionOperationCancelled(operationId))
+                {
+                    Debug.Log($"HostOnline cancelled: {exception.Message}");
+                }
+                else
+                {
+                    Debug.LogError($"Relay host setup failed: {exception}");
+                    Status = "Failed to start online host.";
+                    sessionOperationInProgress = false;
+                }
+            }
+            finally
+            {
+                if (operationId != 0)
+                {
+                    CompleteSessionOperation(operationId);
+                }
+            }
+        }
+
+        public async void JoinOnline(string joinCodeOrAddress)
+        {
+            var operationId = 0;
+            var target = string.Empty;
+
+            try
+            {
+                target = JoinCodeUtility.NormalizeJoinTarget(joinCodeOrAddress);
+                if (string.IsNullOrWhiteSpace(target))
+                {
+                    Status = "Enter a Relay code, or use Join LAN for local testing.";
+                    return;
+                }
+
+                if (JoinCodeUtility.LooksLikeLanAddress(target))
+                {
+                    StartLocalClient(target);
+                    return;
+                }
+
+                if (!JoinCodeUtility.IsValidRelayJoinCode(target))
+                {
+                    Status = $"'{target}' is not a valid Relay code. Codes are {JoinCodeUtility.MinRelayCodeLength}-{JoinCodeUtility.MaxRelayCodeLength} letters or numbers.";
+                    return;
+                }
+
+                if (!TryBeginSessionOperation($"Joining Relay code {target}...", out operationId))
+                {
+                    return;
+                }
+
+                await JoinRelayAsync(target, operationId);
+            }
+            catch (Exception exception) when (operationId != 0 && !IsSessionOperationCancelled(operationId))
+            {
+                Debug.LogWarning($"Relay join failed for code {target}: {exception}");
+                ResetLocalSessionState(JoinCodeUtility.GetFriendlyJoinFailure(exception, target), clearJoinCode: true);
+            }
+            catch (Exception exception)
+            {
+                if (operationId != 0 && IsSessionOperationCancelled(operationId))
+                {
+                    Debug.Log($"JoinOnline cancelled: {exception.Message}");
+                }
+                else
+                {
+                    Debug.LogError($"Relay join setup failed: {exception}");
+                    LastJoinCode = string.Empty;
+                    LastRelayRegion = string.Empty;
+                    Status = "Failed to start Relay join. Try again.";
+                    sessionOperationInProgress = false;
+                }
+            }
+            finally
+            {
+                if (operationId != 0)
+                {
+                    CompleteSessionOperation(operationId);
+                }
+            }
+        }
+    }
+}

--- a/Space Game/Assets/Scripts/Networking/NetworkSessionManager.Online.cs.meta
+++ b/Space Game/Assets/Scripts/Networking/NetworkSessionManager.Online.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8f40087745ac42f19eee40bb3df57612
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Space Game/Assets/Scripts/Networking/NetworkSessionManager.cs
+++ b/Space Game/Assets/Scripts/Networking/NetworkSessionManager.cs
@@ -16,8 +16,6 @@ namespace FriendSlop.Networking
 {
     public partial class NetworkSessionManager : MonoBehaviour
     {
-        public static NetworkSessionManager Instance { get; private set; }
-
         // Raised when the local client/host session has ended (disconnect, shutdown,
         // transport failure). UI subscribes to release the gameplay cursor lock so the
         // menu is interactable again. Kept as an event so this class never reaches

--- a/Space Game/Assets/Scripts/Networking/NetworkSessionManager.cs
+++ b/Space Game/Assets/Scripts/Networking/NetworkSessionManager.cs
@@ -14,7 +14,7 @@ using UnityEngine;
 
 namespace FriendSlop.Networking
 {
-    public class NetworkSessionManager : MonoBehaviour
+    public partial class NetworkSessionManager : MonoBehaviour
     {
         public static NetworkSessionManager Instance { get; private set; }
 
@@ -47,128 +47,6 @@ namespace FriendSlop.Networking
         public float PendingConnectionSecondsRemaining => pendingConnectionDeadline > 0f
             ? Mathf.Max(0f, pendingConnectionDeadline - Time.realtimeSinceStartup)
             : 0f;
-
-        private void Awake()
-        {
-            if (Instance != null && Instance != this)
-            {
-                Destroy(gameObject);
-                return;
-            }
-
-            Instance = this;
-            TrySubscribeToNetworkManager();
-        }
-
-        private void OnEnable()
-        {
-            TrySubscribeToNetworkManager();
-        }
-
-        private async void Update()
-        {
-            TrySubscribeToNetworkManager();
-            CheckPendingConnectionTimeout();
-
-            if (currentLobby == null || Time.realtimeSinceStartup < nextLobbyHeartbeat)
-            {
-                return;
-            }
-
-            nextLobbyHeartbeat = Time.realtimeSinceStartup + 15f;
-            try
-            {
-                await WithServiceTimeout(LobbyService.Instance.SendHeartbeatPingAsync(currentLobby.Id), "Lobby heartbeat");
-            }
-            catch (Exception exception)
-            {
-                Debug.LogWarning($"Lobby heartbeat failed: {exception.Message}");
-            }
-        }
-
-        private void OnDisable()
-        {
-            UnsubscribeFromNetworkManager();
-        }
-
-        public async void HostOnline()
-        {
-            if (!TryBeginSessionOperation("Starting online host...", out var operationId))
-            {
-                return;
-            }
-
-            try
-            {
-                await HostRelayAsync(operationId);
-            }
-            catch (Exception exception)
-            {
-                if (IsSessionOperationCancelled(operationId))
-                {
-                    return;
-                }
-
-                Debug.LogWarning($"Relay host failed, falling back to local host: {exception.Message}");
-                sessionOperationInProgress = false;
-                if (StartLocalHost())
-                {
-                    Status = $"Relay unavailable. Local host started on port {localPort}.";
-                }
-            }
-            finally
-            {
-                CompleteSessionOperation(operationId);
-            }
-        }
-
-        public async void JoinOnline(string joinCodeOrAddress)
-        {
-            var target = JoinCodeUtility.NormalizeJoinTarget(joinCodeOrAddress);
-            if (string.IsNullOrWhiteSpace(target))
-            {
-                Status = "Enter a Relay code, or use Join LAN for local testing.";
-                return;
-            }
-
-            if (JoinCodeUtility.LooksLikeLanAddress(target))
-            {
-                StartLocalClient(target);
-                return;
-            }
-
-            if (!JoinCodeUtility.IsValidRelayJoinCode(target))
-            {
-                Status = $"'{target}' is not a valid Relay code. Codes are {JoinCodeUtility.MinRelayCodeLength}-{JoinCodeUtility.MaxRelayCodeLength} letters or numbers.";
-                return;
-            }
-
-            if (!TryBeginSessionOperation($"Joining Relay code {target}...", out var operationId))
-            {
-                return;
-            }
-
-            try
-            {
-                await JoinRelayAsync(target, operationId);
-            }
-            catch (Exception exception)
-            {
-                if (IsSessionOperationCancelled(operationId))
-                {
-                    return;
-                }
-
-                Debug.LogWarning($"Relay join failed for code {target}: {exception}");
-                LastJoinCode = string.Empty;
-                LastRelayRegion = string.Empty;
-                Status = JoinCodeUtility.GetFriendlyJoinFailure(exception, target);
-            }
-            finally
-            {
-                CompleteSessionOperation(operationId);
-            }
-        }
 
         public bool StartLocalHost()
         {
@@ -438,21 +316,6 @@ namespace FriendSlop.Networking
             finally
             {
                 currentLobby = null;
-            }
-        }
-
-        private void OnApplicationQuit()
-        {
-            _ = LeaveLobbyAsync();
-        }
-
-        private void OnDestroy()
-        {
-            UnsubscribeFromNetworkManager();
-
-            if (Instance == this)
-            {
-                Instance = null;
             }
         }
 

--- a/Space Game/Assets/Scripts/Networking/PrototypeNetworkBootstrapper.cs
+++ b/Space Game/Assets/Scripts/Networking/PrototypeNetworkBootstrapper.cs
@@ -5,6 +5,7 @@ using FriendSlop.Loot;
 using FriendSlop.Round;
 using Unity.Netcode;
 using UnityEngine;
+using UnityEngine.SceneManagement;
 
 namespace FriendSlop.Networking
 {
@@ -212,6 +213,7 @@ namespace FriendSlop.Networking
                 }
 
                 var loot = Instantiate(prefab, pos, rot);
+                MoveToActivePlanetScene(loot.gameObject, activeEnv);
                 loot.ServerSetSpawnPose(pos, rot);
                 SpawnNetworkObject(loot.NetworkObject);
             }
@@ -271,8 +273,25 @@ namespace FriendSlop.Networking
                 }
 
                 var monster = Instantiate(monsterPrefab, spawnPoint.position, spawnPoint.rotation);
+                MoveToActivePlanetScene(monster.gameObject, activeEnv);
                 SpawnNetworkObject(monster.NetworkObject);
             }
+        }
+
+        private static void MoveToActivePlanetScene(GameObject spawnedObject, PlanetEnvironment activeEnv)
+        {
+            if (spawnedObject == null || activeEnv == null)
+            {
+                return;
+            }
+
+            var targetScene = activeEnv.gameObject.scene;
+            if (!targetScene.IsValid() || !targetScene.isLoaded || spawnedObject.scene == targetScene)
+            {
+                return;
+            }
+
+            SceneManager.MoveGameObjectToScene(spawnedObject, targetScene);
         }
 
         private void SpawnNetworkObject(NetworkObject networkObject)

--- a/Space Game/Assets/Scripts/Networking/PrototypeNetworkBootstrapper.cs
+++ b/Space Game/Assets/Scripts/Networking/PrototypeNetworkBootstrapper.cs
@@ -3,6 +3,7 @@ using FriendSlop.Core;
 using FriendSlop.Hazards;
 using FriendSlop.Loot;
 using FriendSlop.Round;
+using FriendSlop.SceneManagement;
 using Unity.Netcode;
 using UnityEngine;
 using UnityEngine.SceneManagement;
@@ -12,6 +13,7 @@ namespace FriendSlop.Networking
     public class PrototypeNetworkBootstrapper : MonoBehaviour
     {
         [SerializeField] private RoundManager roundManagerPrefab;
+        [SerializeField] private NetworkSceneTransitionService sceneTransitionService;
         [SerializeField] private Transform[] playerSpawnPoints;
         [SerializeField] private Transform[] shipSpawnPoints;
         [SerializeField] private NetworkLootItem[] lootPrefabs;
@@ -159,7 +161,24 @@ namespace FriendSlop.Networking
             var round = Instantiate(roundManagerPrefab);
             round.ConfigureSpawnPoints(playerSpawnPoints);
             round.ConfigureShipSpawnPoints(shipSpawnPoints);
+            round.ConfigureSceneTransitionService(ResolveSceneTransitionService());
             SpawnNetworkObject(round.NetworkObject);
+        }
+
+        private NetworkSceneTransitionService ResolveSceneTransitionService()
+        {
+            if (sceneTransitionService != null)
+            {
+                return sceneTransitionService;
+            }
+
+            var networkManager = subscribedManager != null ? subscribedManager : NetworkManager.Singleton;
+            if (networkManager != null)
+            {
+                sceneTransitionService = networkManager.GetComponent<NetworkSceneTransitionService>();
+            }
+
+            return sceneTransitionService;
         }
 
         private void SpawnLoot(PlanetEnvironment activeEnv)

--- a/Space Game/Assets/Scripts/Player/NetworkFirstPersonController.Health.cs
+++ b/Space Game/Assets/Scripts/Player/NetworkFirstPersonController.Health.cs
@@ -22,6 +22,11 @@ namespace FriendSlop.Player
         private float _deathOverheadTimer;
         private bool _spectating;
         private int _spectatorIndex;
+        private readonly List<NetworkFirstPersonController> _aliveSpectateTargets = new();
+        private string _spectatorTargetLabel = string.Empty;
+        private int _spectatorTargetLabelAliveCount = -1;
+        private int _spectatorTargetLabelIndex = -1;
+        private ulong _spectatorTargetLabelClientId = ulong.MaxValue;
 
         public bool IsDead => _health.Value <= 0;
         public float HealthPercent => maxHealth > 0 ? Mathf.Clamp01((float)_health.Value / maxHealth) : 0f;
@@ -30,24 +35,7 @@ namespace FriendSlop.Player
         public bool IsDeadLocally => IsOwner && _isDead;
         public bool IsSpectatingLocally => IsOwner && _isDead && _spectating;
 
-        public string SpectatorTargetLabel
-        {
-            get
-            {
-                if (!_spectating) return string.Empty;
-                var alive = new List<NetworkFirstPersonController>();
-                foreach (var p in ActivePlayers)
-                {
-                    if (p != null && p != this && p.IsSpawned && !p.IsDead)
-                        alive.Add(p);
-                }
-                if (alive.Count == 0) return "nobody";
-                var idx = ((_spectatorIndex % alive.Count) + alive.Count) % alive.Count;
-                var target = alive[idx];
-                var serverId = NetworkManager.Singleton != null ? NetworkManager.ServerClientId : 0UL;
-                return target.OwnerClientId == serverId ? "Host" : $"Player {target.OwnerClientId}";
-            }
-        }
+        public string SpectatorTargetLabel => _spectating ? _spectatorTargetLabel : string.Empty;
 
         private void OnHealthChanged(int previous, int current)
         {
@@ -111,6 +99,7 @@ namespace FriendSlop.Player
             _spectating = false;
             _deathOverheadTimer = 5f;
             _spectatorIndex = 0;
+            ResetSpectatorTargetLabel();
             if (characterController != null) characterController.enabled = false;
             if (playerCamera != null) playerCamera.transform.SetParent(null);
         }
@@ -122,6 +111,7 @@ namespace FriendSlop.Player
             _isDead = false;
             _spectating = false;
             _deathOverheadTimer = 0f;
+            ResetSpectatorTargetLabel();
             if (playerCamera != null && cameraRoot != null)
             {
                 playerCamera.transform.SetParent(cameraRoot);
@@ -158,23 +148,19 @@ namespace FriendSlop.Player
                 return;
             }
 
+            RefreshAliveSpectateTargets();
+
             if (Keyboard.current != null && !GameplayInputState.IsBlocked)
             {
-                if (Keyboard.current.eKey.wasPressedThisFrame) CycleSpectateTarget(1);
-                if (Keyboard.current.qKey.wasPressedThisFrame) CycleSpectateTarget(-1);
+                if (Keyboard.current.eKey.wasPressedThisFrame) CycleSpectateTarget(1, _aliveSpectateTargets.Count);
+                if (Keyboard.current.qKey.wasPressedThisFrame) CycleSpectateTarget(-1, _aliveSpectateTargets.Count);
             }
 
-            var alive = new List<NetworkFirstPersonController>();
-            foreach (var p in ActivePlayers)
+            if (_aliveSpectateTargets.Count > 0)
             {
-                if (p != null && p != this && p.IsSpawned && !p.IsDead)
-                    alive.Add(p);
-            }
-
-            if (alive.Count > 0)
-            {
-                _spectatorIndex = ((_spectatorIndex % alive.Count) + alive.Count) % alive.Count;
-                var target = alive[_spectatorIndex];
+                _spectatorIndex = ((_spectatorIndex % _aliveSpectateTargets.Count) + _aliveSpectateTargets.Count) % _aliveSpectateTargets.Count;
+                var target = _aliveSpectateTargets[_spectatorIndex];
+                UpdateSpectatorTargetLabel(_aliveSpectateTargets.Count, target);
                 if (target.PlayerCamera != null)
                 {
                     playerCamera.transform.position = target.PlayerCamera.transform.position;
@@ -183,6 +169,7 @@ namespace FriendSlop.Player
             }
             else
             {
+                UpdateSpectatorTargetLabel(0, null);
                 var overheadPos = transform.position + up * 8f;
                 playerCamera.transform.position = overheadPos;
                 var surfaceForward = Vector3.ProjectOnPlane(transform.forward, up);
@@ -194,14 +181,66 @@ namespace FriendSlop.Player
 
         private void CycleSpectateTarget(int direction)
         {
+            CycleSpectateTarget(direction, CountAliveSpectateTargets());
+        }
+
+        private void CycleSpectateTarget(int direction, int aliveCount)
+        {
+            if (aliveCount == 0) return;
+            _spectatorIndex = ((_spectatorIndex + direction) % aliveCount + aliveCount) % aliveCount;
+        }
+
+        private int CountAliveSpectateTargets()
+        {
             var aliveCount = 0;
             foreach (var p in ActivePlayers)
             {
                 if (p != null && p != this && p.IsSpawned && !p.IsDead)
                     aliveCount++;
             }
-            if (aliveCount == 0) return;
-            _spectatorIndex = ((_spectatorIndex + direction) % aliveCount + aliveCount) % aliveCount;
+            return aliveCount;
+        }
+
+        private void RefreshAliveSpectateTargets()
+        {
+            _aliveSpectateTargets.Clear();
+            foreach (var p in ActivePlayers)
+            {
+                if (p != null && p != this && p.IsSpawned && !p.IsDead)
+                    _aliveSpectateTargets.Add(p);
+            }
+        }
+
+        private void UpdateSpectatorTargetLabel(int aliveCount, NetworkFirstPersonController target)
+        {
+            var targetClientId = target != null ? target.OwnerClientId : ulong.MaxValue;
+            if (_spectatorTargetLabelAliveCount == aliveCount
+                && _spectatorTargetLabelIndex == _spectatorIndex
+                && _spectatorTargetLabelClientId == targetClientId)
+            {
+                return;
+            }
+
+            _spectatorTargetLabelAliveCount = aliveCount;
+            _spectatorTargetLabelIndex = _spectatorIndex;
+            _spectatorTargetLabelClientId = targetClientId;
+
+            if (target == null)
+            {
+                _spectatorTargetLabel = "nobody";
+                return;
+            }
+
+            var serverId = NetworkManager.Singleton != null ? NetworkManager.ServerClientId : 0UL;
+            _spectatorTargetLabel = target.OwnerClientId == serverId ? "Host" : $"Player {target.OwnerClientId}";
+        }
+
+        private void ResetSpectatorTargetLabel()
+        {
+            _spectatorTargetLabel = string.Empty;
+            _spectatorTargetLabelAliveCount = -1;
+            _spectatorTargetLabelIndex = -1;
+            _spectatorTargetLabelClientId = ulong.MaxValue;
         }
     }
 }

--- a/Space Game/Assets/Scripts/Player/NetworkFirstPersonController.Lifecycle.cs
+++ b/Space Game/Assets/Scripts/Player/NetworkFirstPersonController.Lifecycle.cs
@@ -1,0 +1,68 @@
+using FriendSlop.Round;
+using UnityEngine;
+
+namespace FriendSlop.Player
+{
+    public partial class NetworkFirstPersonController
+    {
+        public override void OnNetworkDespawn()
+        {
+            if (IsServer)
+            {
+                ServerForceDropHeld(Vector3.zero);
+                if (_heldPlayer != null) ServerDropHeldPlayer(Vector3.zero);
+                if (IsBeingCarried.Value)
+                {
+                    var carrier = FindByClientId(CarriedByClientId.Value);
+                    carrier?.ServerDropHeldPlayer(Vector3.zero);
+                }
+            }
+
+            if (IsOwner)
+            {
+                _health.OnValueChanged -= OnHealthChanged;
+                if (_subscribedToRoundPhase)
+                {
+                    var rm = RoundManager.Instance;
+                    if (rm != null) rm.Phase.OnValueChanged -= OnRoundPhaseChanged;
+                    _subscribedToRoundPhase = false;
+                }
+
+                ReparentDetachedDeathCameraForDespawn();
+            }
+
+            ActivePlayers.Remove(this);
+
+            if (LocalPlayer == this)
+            {
+                LocalPlayer = null;
+                Cursor.lockState = CursorLockMode.None;
+                Cursor.visible = true;
+            }
+        }
+
+        public override void OnDestroy()
+        {
+            base.OnDestroy();
+            ActivePlayers.Remove(this);
+        }
+
+        private void ReparentDetachedDeathCameraForDespawn()
+        {
+            if (!_isDead || playerCamera == null || cameraRoot == null)
+            {
+                return;
+            }
+
+            var cameraTransform = playerCamera.transform;
+            if (cameraTransform == cameraRoot || cameraTransform.parent != null)
+            {
+                return;
+            }
+
+            cameraTransform.SetParent(cameraRoot, false);
+            cameraTransform.localPosition = Vector3.zero;
+            cameraTransform.localRotation = Quaternion.identity;
+        }
+    }
+}

--- a/Space Game/Assets/Scripts/Player/NetworkFirstPersonController.Lifecycle.cs.meta
+++ b/Space Game/Assets/Scripts/Player/NetworkFirstPersonController.Lifecycle.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: da190ddceae448ee8eb8192fbebf6183
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Space Game/Assets/Scripts/Player/NetworkFirstPersonController.PlayerCarrying.cs
+++ b/Space Game/Assets/Scripts/Player/NetworkFirstPersonController.PlayerCarrying.cs
@@ -1,3 +1,4 @@
+using FriendSlop.Core;
 using FriendSlop.Round;
 using Unity.Netcode;
 using UnityEngine;
@@ -134,6 +135,7 @@ namespace FriendSlop.Player
             if (rpcParams.Receive.SenderClientId != OwnerClientId || _heldPlayer == null) return;
             var carrier = FindByClientId(rpcParams.Receive.SenderClientId);
             if (carrier != null && Vector3.SqrMagnitude(position - carrier.transform.position) > 36f) return;
+            position = CarrySurfaceUtility.ClampTargetAboveSurface(position);
             _heldPlayer.ServerMoveAsCarried(position, rotation);
         }
 

--- a/Space Game/Assets/Scripts/Player/NetworkFirstPersonController.cs
+++ b/Space Game/Assets/Scripts/Player/NetworkFirstPersonController.cs
@@ -219,46 +219,6 @@ namespace FriendSlop.Player
             }
         }
 
-        public override void OnNetworkDespawn()
-        {
-            if (IsServer)
-            {
-                ServerForceDropHeld(Vector3.zero);
-                if (_heldPlayer != null) ServerDropHeldPlayer(Vector3.zero);
-                if (IsBeingCarried.Value)
-                {
-                    var carrier = FindByClientId(CarriedByClientId.Value);
-                    carrier?.ServerDropHeldPlayer(Vector3.zero);
-                }
-            }
-
-            if (IsOwner)
-            {
-                _health.OnValueChanged -= OnHealthChanged;
-                if (_subscribedToRoundPhase)
-                {
-                    var rm = RoundManager.Instance;
-                    if (rm != null) rm.Phase.OnValueChanged -= OnRoundPhaseChanged;
-                    _subscribedToRoundPhase = false;
-                }
-            }
-
-            ActivePlayers.Remove(this);
-
-            if (LocalPlayer == this)
-            {
-                LocalPlayer = null;
-                Cursor.lockState = CursorLockMode.None;
-                Cursor.visible = true;
-            }
-        }
-
-        public override void OnDestroy()
-        {
-            base.OnDestroy();
-            ActivePlayers.Remove(this);
-        }
-
         private void ConfigureLocalPlayer(bool isLocal)
         {
             if (playerCamera != null)

--- a/Space Game/Assets/Scripts/Round/Objectives/QuotaObjective.cs
+++ b/Space Game/Assets/Scripts/Round/Objectives/QuotaObjective.cs
@@ -53,6 +53,20 @@ namespace FriendSlop.Round
             return $"{prefix}  |  {boarding}";
         }
 
+        public override string BuildSuccessText(RoundManager round)
+        {
+            if (round == null) return "QUOTA MET.";
+            var target = ResolveTarget(round);
+            return $"QUOTA MET on {FormatPlanetLabel(round)}.\nCollected ${round.CollectedValue.Value} / ${target}.";
+        }
+
+        public override string BuildFailureText(RoundManager round)
+        {
+            if (round == null) return "QUOTA FAILED.";
+            var target = ResolveTarget(round);
+            return $"QUOTA FAILED on {FormatPlanetLabel(round)}.\nCollected ${round.CollectedValue.Value} / ${target} before time ran out.";
+        }
+
         private int ResolveTarget(RoundManager round)
         {
             return quotaOverride > 0 ? quotaOverride : Mathf.Max(1, round.Quota.Value);

--- a/Space Game/Assets/Scripts/Round/Objectives/RocketAssemblyObjective.cs
+++ b/Space Game/Assets/Scripts/Round/Objectives/RocketAssemblyObjective.cs
@@ -31,6 +31,20 @@ namespace FriendSlop.Round
             return $"Parts: {Format(round.HasCockpit.Value, "Cockpit")} | {Format(round.HasWings.Value, "Wings")} | {Format(round.HasEngine.Value, "Engine")}";
         }
 
+        public override string BuildSuccessText(RoundManager round)
+        {
+            return round != null
+                ? $"ROCKET ASSEMBLED on {FormatPlanetLabel(round)}."
+                : "ROCKET ASSEMBLED.";
+        }
+
+        public override string BuildFailureText(RoundManager round)
+        {
+            if (round == null) return "ROCKET NOT READY.";
+            return $"ROCKET NOT READY on {FormatPlanetLabel(round)}.\n" +
+                   $"{Format(round.HasCockpit.Value, "Cockpit")}, {Format(round.HasWings.Value, "Wings")}, {Format(round.HasEngine.Value, "Engine")}.";
+        }
+
         private static string Format(bool installed, string label)
         {
             return installed ? $"{label} OK" : $"{label} missing";

--- a/Space Game/Assets/Scripts/Round/Objectives/RoundObjective.cs
+++ b/Space Game/Assets/Scripts/Round/Objectives/RoundObjective.cs
@@ -21,5 +21,14 @@ namespace FriendSlop.Round
         // HUD progress string shown while the round is active. Returning empty
         // hides the line.
         public virtual string BuildHudStatus(RoundManager round) => string.Empty;
+
+        public abstract string BuildSuccessText(RoundManager round);
+        public abstract string BuildFailureText(RoundManager round);
+
+        protected static string FormatPlanetLabel(RoundManager round)
+        {
+            var planet = round != null ? round.CurrentPlanet : null;
+            return planet != null ? $"{planet.DisplayName} (Tier {planet.Tier})" : "Unknown planet";
+        }
     }
 }

--- a/Space Game/Assets/Scripts/Round/Objectives/SurvivalObjective.cs
+++ b/Space Game/Assets/Scripts/Round/Objectives/SurvivalObjective.cs
@@ -32,5 +32,20 @@ namespace FriendSlop.Round
             if (round == null) return string.Empty;
             return $"Survive: {RoundManager.FormatTime(round.TimeRemaining.Value)}";
         }
+
+        public override string BuildSuccessText(RoundManager round)
+        {
+            var suffix = requireBoardingOnSurvive ? "Crew survived and boarded." : "Crew survived the timer.";
+            return round != null
+                ? $"SURVIVED on {FormatPlanetLabel(round)}.\n{suffix}"
+                : "SURVIVED.";
+        }
+
+        public override string BuildFailureText(RoundManager round)
+        {
+            return round != null
+                ? $"SURVIVAL FAILED on {FormatPlanetLabel(round)}.\nTimer expired before everyone boarded."
+                : "SURVIVAL FAILED.";
+        }
     }
 }

--- a/Space Game/Assets/Scripts/Round/PlanetSceneOrchestrator.cs
+++ b/Space Game/Assets/Scripts/Round/PlanetSceneOrchestrator.cs
@@ -87,14 +87,8 @@ namespace FriendSlop.Round
                 yield break;
             }
 
-            if (SceneUtility.GetBuildIndexByScenePath(targetPath) < 0)
+            if (WarnMissingPlanetSceneIfNeeded(targetPath))
             {
-                if (warnedMissingPlanetScenes.Add(targetPath))
-                {
-                    Debug.LogWarning(
-                        $"RoundManager: planet scene '{targetPath}' is not in Build Settings; skipping additive load. " +
-                        "(Run Tools/Friend Slop/Extract Tier 1 Into Scene to author it.)");
-                }
                 FinishPlanetSceneReconcile(targetPath);
                 yield break;
             }
@@ -193,6 +187,21 @@ namespace FriendSlop.Round
         {
             if (warnedFailedPlanetSceneLoads.Add($"{scenePath}|{reason}"))
                 Debug.LogError($"RoundManager: cannot load planet scene '{scenePath}' ({reason}).");
+        }
+
+        private bool WarnMissingPlanetSceneIfNeeded(string scenePath)
+        {
+            if (SceneUtility.GetBuildIndexByScenePath(scenePath) >= 0)
+                return false;
+
+            if (warnedMissingPlanetScenes.Add(scenePath))
+            {
+                Debug.LogWarning(
+                    $"RoundManager: planet scene '{scenePath}' is not in Build Settings; skipping additive load. " +
+                    "(Run Tools/Friend Slop/Extract Tier 1 Into Scene to author it.)");
+            }
+
+            return true;
         }
 
         private static PlanetDefinition ResolveSceneOwner(PlanetDefinition planet, PlanetCatalog catalog)

--- a/Space Game/Assets/Scripts/Round/PlanetSceneOrchestrator.cs
+++ b/Space Game/Assets/Scripts/Round/PlanetSceneOrchestrator.cs
@@ -1,0 +1,215 @@
+using System.Collections;
+using System.Collections.Generic;
+using FriendSlop.SceneManagement;
+using Unity.Netcode;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+
+namespace FriendSlop.Round
+{
+    public sealed class PlanetSceneOrchestrator : NetworkBehaviour
+    {
+        public const float SceneEventRetrySeconds = 12f;
+
+        private NetworkSceneTransitionService sceneTransitionService;
+        private string activePlanetScenePath = string.Empty;
+        private Coroutine planetSceneReconcileCoroutine;
+        private string planetSceneReconcileTargetPath = string.Empty;
+        private readonly HashSet<string> warnedMissingPlanetScenes = new();
+        private readonly HashSet<string> warnedFailedPlanetSceneLoads = new();
+
+        private bool HasServerAuthority =>
+            IsServer || (NetworkManager.Singleton != null && NetworkManager.Singleton.IsServer);
+
+        private NetworkSceneTransitionService SceneTransitionService =>
+            sceneTransitionService != null ? sceneTransitionService : NetworkSceneTransitionService.Instance;
+
+        public void Initialize(NetworkSceneTransitionService service)
+        {
+            sceneTransitionService = service;
+        }
+
+        public void ServerReconcilePlanetScenes(PlanetDefinition planet, PlanetCatalog catalog)
+        {
+            if (!HasServerAuthority) return;
+
+            var sceneOwner = ResolveSceneOwner(planet, catalog);
+            var targetPath = sceneOwner != null ? sceneOwner.PlanetScene.ScenePath : string.Empty;
+            if (planetSceneReconcileCoroutine != null)
+            {
+                if (string.Equals(planetSceneReconcileTargetPath, targetPath,
+                        System.StringComparison.OrdinalIgnoreCase))
+                {
+                    return;
+                }
+
+                StopCoroutine(planetSceneReconcileCoroutine);
+                planetSceneReconcileCoroutine = null;
+            }
+
+            // Defer to next frame so this never runs while NetworkManager's
+            // HostServerInitialize is still on the stack. The legacy fallback in
+            // RoundManager keeps the active env bound during the one-frame gap.
+            planetSceneReconcileTargetPath = targetPath;
+            planetSceneReconcileCoroutine = StartCoroutine(ServerReconcilePlanetScenesDeferred(sceneOwner, targetPath));
+        }
+
+        private IEnumerator ServerReconcilePlanetScenesDeferred(PlanetDefinition sceneOwner, string targetPath)
+        {
+            yield return null;
+            if (this == null || !HasServerAuthority)
+            {
+                FinishPlanetSceneReconcile(targetPath);
+                yield break;
+            }
+
+            var service = SceneTransitionService;
+            var hasScene = sceneOwner != null;
+
+            if (!string.IsNullOrEmpty(activePlanetScenePath)
+                && !string.Equals(activePlanetScenePath, targetPath, System.StringComparison.OrdinalIgnoreCase))
+            {
+                if (service == null)
+                {
+                    WarnFailedPlanetSceneLoad(activePlanetScenePath,
+                        "no NetworkSceneTransitionService exists in the active scene");
+                    activePlanetScenePath = string.Empty;
+                }
+                else
+                {
+                    yield return ServerUnloadActivePlanetScene(service, targetPath);
+                }
+            }
+
+            if (!hasScene)
+            {
+                FinishPlanetSceneReconcile(targetPath);
+                yield break;
+            }
+
+            if (SceneUtility.GetBuildIndexByScenePath(targetPath) < 0)
+            {
+                if (warnedMissingPlanetScenes.Add(targetPath))
+                {
+                    Debug.LogWarning(
+                        $"RoundManager: planet scene '{targetPath}' is not in Build Settings; skipping additive load. " +
+                        "(Run Tools/Friend Slop/Extract Tier 1 Into Scene to author it.)");
+                }
+                FinishPlanetSceneReconcile(targetPath);
+                yield break;
+            }
+
+            if (service == null)
+            {
+                WarnFailedPlanetSceneLoad(targetPath,
+                    "no NetworkSceneTransitionService exists in the active scene");
+                FinishPlanetSceneReconcile(targetPath);
+                yield break;
+            }
+
+            if (service.WasServerSceneLoadStarted(targetPath))
+            {
+                activePlanetScenePath = targetPath;
+                FinishPlanetSceneReconcile(targetPath);
+                yield break;
+            }
+
+            var deadline = Time.time + SceneEventRetrySeconds;
+            while (true)
+            {
+                var status = service.ServerLoadScene(sceneOwner.PlanetScene);
+                if (status == SceneEventProgressStatus.Started)
+                {
+                    activePlanetScenePath = targetPath;
+                    FinishPlanetSceneReconcile(targetPath);
+                    yield break;
+                }
+
+                if (status == SceneEventProgressStatus.SceneEventInProgress && Time.time < deadline)
+                {
+                    yield return null;
+                    service = SceneTransitionService;
+                    if (service == null)
+                    {
+                        WarnFailedPlanetSceneLoad(targetPath,
+                            "NetworkSceneTransitionService disappeared while waiting for Netcode scene event");
+                        FinishPlanetSceneReconcile(targetPath);
+                        yield break;
+                    }
+                    continue;
+                }
+
+                WarnFailedPlanetSceneLoad(targetPath, $"Netcode returned {status}");
+                FinishPlanetSceneReconcile(targetPath);
+                yield break;
+            }
+        }
+
+        private IEnumerator ServerUnloadActivePlanetScene(NetworkSceneTransitionService service, string nextTargetPath)
+        {
+            var previousPath = activePlanetScenePath;
+            var deadline = Time.time + SceneEventRetrySeconds;
+            while (!string.IsNullOrEmpty(previousPath))
+            {
+                var status = service.ServerUnloadScenePath(previousPath);
+                if (status == SceneEventProgressStatus.Started || status == SceneEventProgressStatus.SceneNotLoaded)
+                {
+                    activePlanetScenePath = string.Empty;
+                    yield break;
+                }
+
+                if (status == SceneEventProgressStatus.SceneEventInProgress && Time.time < deadline)
+                {
+                    yield return null;
+                    service = SceneTransitionService;
+                    if (service != null) continue;
+                    WarnFailedPlanetSceneLoad(nextTargetPath,
+                        "NetworkSceneTransitionService disappeared while unloading previous planet scene");
+                    activePlanetScenePath = string.Empty;
+                    yield break;
+                }
+
+                Debug.LogWarning(
+                    $"RoundManager: could not unload previous planet scene '{previousPath}' before loading '{nextTargetPath}' " +
+                    $"(Netcode returned {status}).");
+                activePlanetScenePath = string.Empty;
+                yield break;
+            }
+        }
+
+        private void FinishPlanetSceneReconcile(string targetPath)
+        {
+            if (!string.Equals(planetSceneReconcileTargetPath, targetPath,
+                    System.StringComparison.OrdinalIgnoreCase))
+            {
+                return;
+            }
+
+            planetSceneReconcileCoroutine = null;
+            planetSceneReconcileTargetPath = string.Empty;
+        }
+
+        private void WarnFailedPlanetSceneLoad(string scenePath, string reason)
+        {
+            if (warnedFailedPlanetSceneLoads.Add($"{scenePath}|{reason}"))
+                Debug.LogError($"RoundManager: cannot load planet scene '{scenePath}' ({reason}).");
+        }
+
+        private static PlanetDefinition ResolveSceneOwner(PlanetDefinition planet, PlanetCatalog catalog)
+        {
+            if (planet == null) return null;
+            if (planet.HasPlanetScene) return planet;
+            if (catalog == null) return null;
+
+            for (var i = 0; i < catalog.Count; i++)
+            {
+                var candidate = catalog.GetByIndex(i);
+                if (candidate == null) continue;
+                if (candidate == planet) continue;
+                if (candidate.Tier != planet.Tier) continue;
+                if (candidate.HasPlanetScene) return candidate;
+            }
+            return null;
+        }
+    }
+}

--- a/Space Game/Assets/Scripts/Round/PlanetSceneOrchestrator.cs
+++ b/Space Game/Assets/Scripts/Round/PlanetSceneOrchestrator.cs
@@ -22,7 +22,7 @@ namespace FriendSlop.Round
             IsServer || (NetworkManager.Singleton != null && NetworkManager.Singleton.IsServer);
 
         private NetworkSceneTransitionService SceneTransitionService =>
-            sceneTransitionService != null ? sceneTransitionService : NetworkSceneTransitionService.Instance;
+            sceneTransitionService;
 
         public void Initialize(NetworkSceneTransitionService service)
         {

--- a/Space Game/Assets/Scripts/Round/PlanetSceneOrchestrator.cs.meta
+++ b/Space Game/Assets/Scripts/Round/PlanetSceneOrchestrator.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: ff57778c35b84c7d9a0c54f104eecbcb

--- a/Space Game/Assets/Scripts/Round/RoundManager.SceneTransitions.cs
+++ b/Space Game/Assets/Scripts/Round/RoundManager.SceneTransitions.cs
@@ -1,0 +1,15 @@
+using FriendSlop.SceneManagement;
+
+namespace FriendSlop.Round
+{
+    public partial class RoundManager
+    {
+        private NetworkSceneTransitionService sceneTransitionService;
+
+        public void ConfigureSceneTransitionService(NetworkSceneTransitionService service)
+        {
+            sceneTransitionService = service;
+            EnsurePlanetSceneOrchestrator()?.Initialize(service);
+        }
+    }
+}

--- a/Space Game/Assets/Scripts/Round/RoundManager.SceneTransitions.cs.meta
+++ b/Space Game/Assets/Scripts/Round/RoundManager.SceneTransitions.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d7e58a6d2eea45c4ba09760b92b53a69
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Space Game/Assets/Scripts/Round/RoundManager.cs
+++ b/Space Game/Assets/Scripts/Round/RoundManager.cs
@@ -25,6 +25,7 @@ namespace FriendSlop.Round
         [Header("Planet Progression")]
         [SerializeField] private PlanetCatalog planetCatalog;
         [SerializeField] private PlanetDefinition startingPlanet;
+        [SerializeField] private PlanetSceneOrchestrator planetSceneOrchestrator;
 
         [Header("Objective")]
         [SerializeField] private RoundObjective defaultObjective;
@@ -58,17 +59,6 @@ namespace FriendSlop.Round
         private Coroutine _transitionCoroutine;
         private const float TransitionFadeSeconds = 1.0f;
         private const float TransitionHoldSeconds = 0.8f;
-        private const float PlanetSceneEventRetrySeconds = 12f;
-
-        // Server-side bookkeeping: which planet scene we last asked Netcode to load.
-        // Used to unload the previous planet scene when switching to a new one.
-        private string _activePlanetScenePath = string.Empty;
-        private Coroutine _planetSceneReconcileCoroutine;
-        private string _planetSceneReconcileTargetPath = string.Empty;
-        // Per-instance dedup so the "scene not in Build Settings" warning fires once per
-        // missing path instead of every time ApplyActivePlanetEnvironment is invoked.
-        private readonly HashSet<string> _warnedMissingPlanetScenes = new();
-        private readonly HashSet<string> _warnedFailedPlanetSceneLoads = new();
 
         public void ConfigureSpawnPoints(Transform[] spawnPoints)
         {
@@ -80,9 +70,19 @@ namespace FriendSlop.Round
             shipSpawnPoints = spawnPoints;
         }
 
+        private PlanetSceneOrchestrator EnsurePlanetSceneOrchestrator()
+        {
+            if (planetSceneOrchestrator == null)
+                planetSceneOrchestrator = GetComponent<PlanetSceneOrchestrator>();
+            if (planetSceneOrchestrator == null && !IsSpawned)
+                planetSceneOrchestrator = gameObject.AddComponent<PlanetSceneOrchestrator>();
+            return planetSceneOrchestrator;
+        }
+
         private void Awake()
         {
             Instance = this;
+            EnsurePlanetSceneOrchestrator();
             // NetworkList must exist before OnNetworkSpawn so the server's first writes replicate.
             NextPlanetChoiceIndices = new NetworkList<int>();
         }
@@ -99,6 +99,8 @@ namespace FriendSlop.Round
 
         public override void OnNetworkSpawn()
         {
+            EnsurePlanetSceneOrchestrator()?.Initialize(NetworkSceneTransitionService.Instance);
+
             if (NetworkManager != null)
             {
                 NetworkManager.OnClientDisconnectCallback += HandleClientDisconnect;
@@ -170,7 +172,7 @@ namespace FriendSlop.Round
             // doesn't match, unload it. Scene loads are async - when the env Awakes inside
             // the new scene it fires Registered, which calls back into this method.
             if (IsServer)
-                ServerReconcilePlanetScenes(planet);
+                EnsurePlanetSceneOrchestrator()?.ServerReconcilePlanetScenes(planet, planetCatalog);
 
             // Search AllEnvironments so we can find and enable planets whose roots are disabled.
             var activeEnv = FindBindableEnvironment(planet);
@@ -203,176 +205,6 @@ namespace FriendSlop.Round
         public bool IsEnvironmentActiveForCurrentPlanet(PlanetEnvironment env)
         {
             return env != null && env == FindBindableEnvironment(CurrentPlanet);
-        }
-
-        private void ServerReconcilePlanetScenes(PlanetDefinition planet)
-        {
-            var sceneOwner = ResolveSceneOwner(planet);
-            var targetPath = sceneOwner != null ? sceneOwner.PlanetScene.ScenePath : string.Empty;
-            if (_planetSceneReconcileCoroutine != null)
-            {
-                if (string.Equals(_planetSceneReconcileTargetPath, targetPath,
-                        System.StringComparison.OrdinalIgnoreCase))
-                {
-                    return;
-                }
-
-                StopCoroutine(_planetSceneReconcileCoroutine);
-                _planetSceneReconcileCoroutine = null;
-            }
-
-            // Defer to next frame so this never runs while NetworkManager's
-            // HostServerInitialize is still on the stack - mid-init SceneManager.LoadScene
-            // calls land in a half-initialized state and have produced "scene event in
-            // progress" / NREs in startup logs. The legacy fallback in
-            // ApplyActivePlanetEnvironment keeps the active env bound from the prototype
-            // scene during the one-frame gap, so gameplay doesn't notice.
-            _planetSceneReconcileTargetPath = targetPath;
-            _planetSceneReconcileCoroutine = StartCoroutine(ServerReconcilePlanetScenesDeferred(sceneOwner, targetPath));
-        }
-
-        private IEnumerator ServerReconcilePlanetScenesDeferred(PlanetDefinition sceneOwner, string targetPath)
-        {
-            yield return null;
-            if (this == null || !IsServer)
-            {
-                FinishPlanetSceneReconcile(targetPath);
-                yield break;
-            }
-
-            var service = NetworkSceneTransitionService.Instance;
-            var hasScene = sceneOwner != null;
-
-            // Unload the previously-loaded planet scene if we're switching away from it.
-            if (!string.IsNullOrEmpty(_activePlanetScenePath) && _activePlanetScenePath != targetPath)
-            {
-                if (service == null)
-                {
-                    WarnFailedPlanetSceneLoad(_activePlanetScenePath,
-                        "no NetworkSceneTransitionService exists in the active scene");
-                    _activePlanetScenePath = string.Empty;
-                }
-                else
-                {
-                    yield return ServerUnloadActivePlanetScene(service, targetPath);
-                }
-            }
-
-            if (!hasScene)
-            {
-                FinishPlanetSceneReconcile(targetPath);
-                yield break;
-            }
-
-            // Build-settings sanity check: a planet asset can reference a scene that the
-            // extractor hasn't authored yet. Skip the additive load with a warning so the
-            // host stays alive on a fresh checkout - the nested fallback env will play.
-            if (UnityEngine.SceneManagement.SceneUtility.GetBuildIndexByScenePath(targetPath) < 0)
-            {
-                if (_warnedMissingPlanetScenes.Add(targetPath))
-                {
-                    Debug.LogWarning(
-                        $"RoundManager: planet scene '{targetPath}' is not in Build Settings; skipping additive load. " +
-                        "(Run Tools/Friend Slop/Extract Tier 1 Into Scene to author it.)");
-                }
-                FinishPlanetSceneReconcile(targetPath);
-                yield break;
-            }
-
-            if (service == null)
-            {
-                WarnFailedPlanetSceneLoad(targetPath,
-                    "no NetworkSceneTransitionService exists in the active scene");
-                FinishPlanetSceneReconcile(targetPath);
-                yield break;
-            }
-
-            if (service.WasServerSceneLoadStarted(targetPath))
-            {
-                _activePlanetScenePath = targetPath;
-                FinishPlanetSceneReconcile(targetPath);
-                yield break;
-            }
-
-            var deadline = Time.time + PlanetSceneEventRetrySeconds;
-            while (true)
-            {
-                var status = service.ServerLoadScene(sceneOwner.PlanetScene);
-                if (status == SceneEventProgressStatus.Started)
-                {
-                    _activePlanetScenePath = targetPath;
-                    FinishPlanetSceneReconcile(targetPath);
-                    yield break;
-                }
-
-                if (status == SceneEventProgressStatus.SceneEventInProgress && Time.time < deadline)
-                {
-                    yield return null;
-                    if (NetworkSceneTransitionService.Instance == null)
-                    {
-                        WarnFailedPlanetSceneLoad(targetPath,
-                            "NetworkSceneTransitionService disappeared while waiting for Netcode scene event");
-                        FinishPlanetSceneReconcile(targetPath);
-                        yield break;
-                    }
-                    service = NetworkSceneTransitionService.Instance;
-                    continue;
-                }
-
-                WarnFailedPlanetSceneLoad(targetPath, $"Netcode returned {status}");
-                FinishPlanetSceneReconcile(targetPath);
-                yield break;
-            }
-        }
-
-        private IEnumerator ServerUnloadActivePlanetScene(NetworkSceneTransitionService service, string nextTargetPath)
-        {
-            var previousPath = _activePlanetScenePath;
-            var deadline = Time.time + PlanetSceneEventRetrySeconds;
-            while (!string.IsNullOrEmpty(previousPath))
-            {
-                var status = service.ServerUnloadScenePath(previousPath);
-                if (status == SceneEventProgressStatus.Started || status == SceneEventProgressStatus.SceneNotLoaded)
-                {
-                    _activePlanetScenePath = string.Empty;
-                    yield break;
-                }
-
-                if (status == SceneEventProgressStatus.SceneEventInProgress && Time.time < deadline)
-                {
-                    yield return null;
-                    service = NetworkSceneTransitionService.Instance;
-                    if (service != null) continue;
-                    WarnFailedPlanetSceneLoad(nextTargetPath,
-                        "NetworkSceneTransitionService disappeared while unloading previous planet scene");
-                    _activePlanetScenePath = string.Empty;
-                    yield break;
-                }
-
-                Debug.LogWarning(
-                    $"RoundManager: could not unload previous planet scene '{previousPath}' before loading '{nextTargetPath}' " +
-                    $"(Netcode returned {status}).");
-                _activePlanetScenePath = string.Empty;
-                yield break;
-            }
-        }
-
-        private void FinishPlanetSceneReconcile(string targetPath)
-        {
-            if (!string.Equals(_planetSceneReconcileTargetPath, targetPath,
-                    System.StringComparison.OrdinalIgnoreCase))
-            {
-                return;
-            }
-
-            _planetSceneReconcileCoroutine = null;
-            _planetSceneReconcileTargetPath = string.Empty;
-        }
-
-        private void WarnFailedPlanetSceneLoad(string scenePath, string reason)
-        {
-            if (_warnedFailedPlanetSceneLoads.Add($"{scenePath}|{reason}"))
-                Debug.LogError($"RoundManager: cannot load planet scene '{scenePath}' ({reason}).");
         }
 
         private static PlanetEnvironment FindBindableEnvironment(PlanetDefinition planet)
@@ -446,27 +278,6 @@ namespace FriendSlop.Round
             if (!HasAnyLiveSpawn(env.PlayerSpawnPoints))
                 return $"PlanetEnvironment '{env.name}' has no live player spawn points";
             return $"PlanetEnvironment '{env.name}' is not ready";
-        }
-
-        // Resolves which planet definition's scene actually backs this planet at runtime.
-        // Returns the planet itself if it has a dedicated scene, otherwise looks for any
-        // other catalog entry at the same tier that does. Tier-2 catalog entries like
-        // DeepHaul/GhostShift currently share Rusty Moon's environment via this fallback.
-        private PlanetDefinition ResolveSceneOwner(PlanetDefinition planet)
-        {
-            if (planet == null) return null;
-            if (planet.HasPlanetScene) return planet;
-            if (planetCatalog == null) return null;
-
-            for (var i = 0; i < planetCatalog.Count; i++)
-            {
-                var candidate = planetCatalog.GetByIndex(i);
-                if (candidate == null) continue;
-                if (candidate == planet) continue;
-                if (candidate.Tier != planet.Tier) continue;
-                if (candidate.HasPlanetScene) return candidate;
-            }
-            return null;
         }
 
         private static bool IsSceneLoadedPlanet(PlanetEnvironment env)
@@ -736,7 +547,7 @@ namespace FriendSlop.Round
             // Same fallback as ApplyActivePlanetEnvironment: accept an exact match OR
             // any same-tier env, so catalog entries without their own scene (DeepHaul,
             // GhostShift, etc.) succeed once the fallback scene's env registers.
-            const float maxEnvWaitSeconds = PlanetSceneEventRetrySeconds + 8f;
+            const float maxEnvWaitSeconds = PlanetSceneOrchestrator.SceneEventRetrySeconds + 8f;
             var envWaitStart = Time.time;
             while (FindRoundReadyEnvironment(next) == null
                    && Time.time - envWaitStart < maxEnvWaitSeconds)

--- a/Space Game/Assets/Scripts/Round/RoundManager.cs
+++ b/Space Game/Assets/Scripts/Round/RoundManager.cs
@@ -9,7 +9,7 @@ using UnityEngine;
 
 namespace FriendSlop.Round
 {
-    public class RoundManager : NetworkBehaviour
+    public partial class RoundManager : NetworkBehaviour
     {
         public static RoundManager Instance { get; private set; }
         public static event System.Action LocalTeleporterFlashRequested;
@@ -99,7 +99,7 @@ namespace FriendSlop.Round
 
         public override void OnNetworkSpawn()
         {
-            EnsurePlanetSceneOrchestrator()?.Initialize(NetworkSceneTransitionService.Instance);
+            EnsurePlanetSceneOrchestrator()?.Initialize(sceneTransitionService);
 
             if (NetworkManager != null)
             {

--- a/Space Game/Assets/Scripts/SceneManagement/NetworkSceneTransitionService.cs
+++ b/Space Game/Assets/Scripts/SceneManagement/NetworkSceneTransitionService.cs
@@ -7,32 +7,11 @@ namespace FriendSlop.SceneManagement
 {
     public class NetworkSceneTransitionService : MonoBehaviour
     {
-        public static NetworkSceneTransitionService Instance { get; private set; }
-
         [SerializeField] private GameSceneCatalog sceneCatalog;
 
         private readonly HashSet<string> serverLoadedScenePaths = new();
 
         public GameSceneCatalog Catalog => sceneCatalog;
-
-        private void Awake()
-        {
-            if (Instance != null && Instance != this)
-            {
-                Destroy(gameObject);
-                return;
-            }
-
-            Instance = this;
-        }
-
-        private void OnDestroy()
-        {
-            if (Instance == this)
-            {
-                Instance = null;
-            }
-        }
 
         public SceneEventProgressStatus ServerLoadScene(GameSceneDefinition scene)
         {

--- a/Space Game/Assets/Scripts/UI/FriendSlopUI.BuildUi.cs
+++ b/Space Game/Assets/Scripts/UI/FriendSlopUI.BuildUi.cs
@@ -229,11 +229,11 @@ namespace FriendSlop.UI
             connectionHintText.gameObject.SetActive(false);
 
             joinInput = CreateInput("JoinInput", menuRoot.transform, "Relay code or LAN IP", new Vector2(0f, 68f));
-            hostButton = CreateButton("Host Online", menuRoot.transform, Vector2.zero, () => NetworkSessionManager.Instance?.HostOnline());
-            joinButton = CreateButton("Join Code", menuRoot.transform, Vector2.zero, () => NetworkSessionManager.Instance?.JoinOnline(joinInput.text));
-            localHostButton = CreateButton("Host LAN", menuRoot.transform, Vector2.zero, () => NetworkSessionManager.Instance?.StartLocalHost());
-            localJoinButton = CreateButton("Join LAN", menuRoot.transform, Vector2.zero, () => NetworkSessionManager.Instance?.StartLocalClient(string.IsNullOrWhiteSpace(joinInput.text) ? "127.0.0.1" : joinInput.text));
-            cancelButton = CreateButton("Cancel", menuRoot.transform, Vector2.zero, () => NetworkSessionManager.Instance?.CancelSessionOperation());
+            hostButton = CreateButton("Host Online", menuRoot.transform, Vector2.zero, () => SessionManager?.HostOnline());
+            joinButton = CreateButton("Join Code", menuRoot.transform, Vector2.zero, () => SessionManager?.JoinOnline(joinInput.text));
+            localHostButton = CreateButton("Host LAN", menuRoot.transform, Vector2.zero, () => SessionManager?.StartLocalHost());
+            localJoinButton = CreateButton("Join LAN", menuRoot.transform, Vector2.zero, () => SessionManager?.StartLocalClient(string.IsNullOrWhiteSpace(joinInput.text) ? "127.0.0.1" : joinInput.text));
+            cancelButton = CreateButton("Cancel", menuRoot.transform, Vector2.zero, () => SessionManager?.CancelSessionOperation());
             cancelButton.gameObject.SetActive(false);
             startButton = CreateButton("Start Round", menuRoot.transform, Vector2.zero, () =>
             {

--- a/Space Game/Assets/Scripts/UI/FriendSlopUI.Dependencies.cs
+++ b/Space Game/Assets/Scripts/UI/FriendSlopUI.Dependencies.cs
@@ -1,0 +1,33 @@
+using FriendSlop.Core;
+using FriendSlop.Networking;
+using Unity.Netcode;
+using UnityEngine;
+
+namespace FriendSlop.UI
+{
+    public partial class FriendSlopUI
+    {
+        [SerializeField] private NetworkSessionManager sessionManager;
+
+        public static bool BlocksGameplayInput => GameplayInputState.IsBlocked;
+
+        private NetworkSessionManager SessionManager
+        {
+            get
+            {
+                if (sessionManager != null)
+                {
+                    return sessionManager;
+                }
+
+                var networkManager = NetworkManager.Singleton;
+                if (networkManager != null)
+                {
+                    sessionManager = networkManager.GetComponent<NetworkSessionManager>();
+                }
+
+                return sessionManager;
+            }
+        }
+    }
+}

--- a/Space Game/Assets/Scripts/UI/FriendSlopUI.Dependencies.cs.meta
+++ b/Space Game/Assets/Scripts/UI/FriendSlopUI.Dependencies.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6d97f8ed6f8f4f4a997dd2b42df72f36
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Space Game/Assets/Scripts/UI/FriendSlopUI.Hud.cs
+++ b/Space Game/Assets/Scripts/UI/FriendSlopUI.Hud.cs
@@ -242,10 +242,9 @@ namespace FriendSlop.UI
             _fadeOverlayImage.color = new Color(0f, 0f, 0f, combinedAlpha);
         }
 
-        public static void RequestTeleporterFlash()
+        private void RequestTeleporterFlash()
         {
-            if (Instance == null) return;
-            Instance._teleporterFlashStartTime = Time.time;
+            _teleporterFlashStartTime = Time.time;
         }
 
         private float ComputeTeleporterFlashAlpha()

--- a/Space Game/Assets/Scripts/UI/FriendSlopUI.Menu.cs
+++ b/Space Game/Assets/Scripts/UI/FriendSlopUI.Menu.cs
@@ -306,15 +306,21 @@ namespace FriendSlop.UI
 
         private static string BuildSuccessResultText(RoundManager round)
         {
-            if (round == null) return "ROCKET ASSEMBLED.";
+            if (round == null) return "OBJECTIVE COMPLETE.";
 
-            var current = FormatPlanetLabel(round.CurrentPlanet);
+            var objectiveText = round.ActiveObjective != null
+                ? round.ActiveObjective.BuildSuccessText(round)
+                : string.Empty;
+            if (string.IsNullOrWhiteSpace(objectiveText))
+                objectiveText = $"OBJECTIVE COMPLETE on {FormatPlanetLabel(round.CurrentPlanet)}.";
+
+            objectiveText = objectiveText.TrimEnd();
             if (round.HasReachedFinalTier)
-                return $"ROCKET ASSEMBLED on {current}.\nFinal tier reached - replay to keep grinding.";
+                return $"{objectiveText}\nFinal tier reached - replay to keep grinding.";
 
             var choices = round.GetOfferedNextPlanetChoices();
             if (choices.Count == 0)
-                return $"ROCKET ASSEMBLED on {current}.\nNo tier {round.NextTier} planets registered yet - host can replay.";
+                return $"{objectiveText}\nNo tier {round.NextTier} planets registered yet - host can replay.";
 
             var next = round.SelectedNextPlanet;
             if (next == null || next.Tier != round.NextTier || !choices.Contains(next))
@@ -328,7 +334,20 @@ namespace FriendSlop.UI
                 optionsLine = $"\n{choices.Count} of {totalForTier} tier {round.NextTier} planets rolled - host can cycle between them.";
             else
                 optionsLine = $"\n{choices.Count} tier {round.NextTier} options - host can cycle.";
-            return $"ROCKET ASSEMBLED on {current}.\nNext: {FormatPlanetLabel(next)}{optionsLine}";
+            return $"{objectiveText}\nNext: {FormatPlanetLabel(next)}{optionsLine}";
+        }
+
+        private static string BuildFailureResultText(RoundManager round)
+        {
+            if (round == null) return "FAILED: back aboard the ship.\nHost can restart the planet run.";
+
+            var objectiveText = round.ActiveObjective != null
+                ? round.ActiveObjective.BuildFailureText(round)
+                : string.Empty;
+            if (string.IsNullOrWhiteSpace(objectiveText))
+                objectiveText = "FAILED: back aboard the ship.";
+
+            return $"{objectiveText.TrimEnd()}\nHost can restart the planet run.";
         }
 
         private static string BuildLobbyQueue(NetworkManager networkManager)

--- a/Space Game/Assets/Scripts/UI/FriendSlopUI.Menu.cs
+++ b/Space Game/Assets/Scripts/UI/FriendSlopUI.Menu.cs
@@ -206,9 +206,8 @@ namespace FriendSlop.UI
 
         private void CopyJoinCodeToClipboard()
         {
-            var code = GetCopyableJoinCode(NetworkSessionManager.Instance != null
-                ? NetworkSessionManager.Instance.LastJoinCode
-                : string.Empty);
+            var session = SessionManager;
+            var code = GetCopyableJoinCode(session != null ? session.LastJoinCode : string.Empty);
             if (string.IsNullOrWhiteSpace(code)) return;
 
             GUIUtility.systemCopyBuffer = code;

--- a/Space Game/Assets/Scripts/UI/FriendSlopUI.cs
+++ b/Space Game/Assets/Scripts/UI/FriendSlopUI.cs
@@ -32,10 +32,6 @@ namespace FriendSlop.UI
         private static readonly Color CancelButtonColor = new Color(0.48f, 0.17f, 0.12f, 0.96f);
         private static readonly Color SuccessButtonColor = new Color(0.16f, 0.42f, 0.24f, 0.96f);
 
-        // ── Singleton ─────────────────────────────────────────────────────────
-        public static FriendSlopUI Instance { get; private set; }
-        public static bool BlocksGameplayInput => Instance != null && Instance.IsBlockingGameplayInput();
-
         // ── Canvas roots ──────────────────────────────────────────────────────
         private Canvas canvas;
         private RectTransform canvasRect;
@@ -150,7 +146,6 @@ namespace FriendSlop.UI
 
         private void Awake()
         {
-            Instance = this;
             font = Resources.GetBuiltinResource<Font>("LegacyRuntime.ttf");
             if (font == null)
                 font = Resources.GetBuiltinResource<Font>("Arial.ttf");
@@ -164,7 +159,7 @@ namespace FriendSlop.UI
         {
             // Register the input-block predicate so Gameplay code can ask "should I ignore
             // input?" without depending on FriendSlop.UI. See FriendSlop.Core.GameplayInputState.
-            GameplayInputState.RegisterBlockProvider(IsBlockingGameplayInput);
+            GameplayInputState.RegisterBlockProvider(this, IsBlockingGameplayInput);
 
             NetworkSessionManager.SessionEnded += HandleSessionEnded;
             NetworkFirstPersonController.LocalPlayerDamaged += HandleLocalPlayerDamaged;
@@ -182,10 +177,7 @@ namespace FriendSlop.UI
             RoundManager.LocalTeleporterFlashRequested -= HandleTeleporterFlashRequested;
             _chatInputFocused = false;
 
-            // Only clear if we're the registered provider; if a fresh UI instance has already
-            // taken over (e.g. scene reload during a host restart) leave its provider in place.
-            if (Instance == this)
-                GameplayInputState.ClearBlockProvider();
+            GameplayInputState.ClearBlockProvider(this);
         }
 
         private void HandleSessionEnded() => UnlockMenuCursor();
@@ -310,7 +302,7 @@ namespace FriendSlop.UI
         private void RefreshUi()
         {
             var networkManager = NetworkManager.Singleton;
-            var session = NetworkSessionManager.Instance;
+            var session = SessionManager;
             var round = RoundManager.Instance;
             var connected = networkManager != null && networkManager.IsListening;
             var isHost = networkManager != null && networkManager.IsHost;
@@ -468,7 +460,7 @@ namespace FriendSlop.UI
 
         private void HandleSessionExitButton()
         {
-            var session = NetworkSessionManager.Instance;
+            var session = SessionManager;
             if (session == null) return;
 
             if (session.CanCancelSessionOperation)

--- a/Space Game/Assets/Scripts/UI/FriendSlopUI.cs
+++ b/Space Game/Assets/Scripts/UI/FriendSlopUI.cs
@@ -413,7 +413,7 @@ namespace FriendSlop.UI
                         : "Host or join to begin.",
                     RoundPhase.Active => string.Empty,
                     RoundPhase.Success => BuildSuccessResultText(round),
-                    RoundPhase.Failed => "FAILED: back aboard the ship.\nHost can restart the planet run.",
+                    RoundPhase.Failed => BuildFailureResultText(round),
                     RoundPhase.AllDead => $"WIPE OUT - everyone died.\nBack aboard with ${round.CollectedValue.Value} collected.",
                     _ => string.Empty
                 };

--- a/Space Game/Assets/Tests/EditMode/Editor/ArchitectureGuardrailTests.cs
+++ b/Space Game/Assets/Tests/EditMode/Editor/ArchitectureGuardrailTests.cs
@@ -1,0 +1,226 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using NUnit.Framework;
+using UnityEngine;
+
+namespace FriendSlop.Tests.EditMode
+{
+    public class ArchitectureGuardrailTests
+    {
+        private const int DefaultRuntimeFileLineLimit = 400;
+
+        private static readonly Dictionary<string, int> ExistingOversizedRuntimeFiles = new()
+        {
+            ["Assets/Scripts/Round/RoundManager.cs"] = 1000,
+            ["Assets/Scripts/Player/NetworkFirstPersonController.cs"] = 739,
+            ["Assets/Scripts/Loot/NetworkLootItem.cs"] = 703,
+            ["Assets/Scripts/Networking/NetworkSessionManager.cs"] = 621,
+            ["Assets/Scripts/Player/PlayerInteractor.cs"] = 529,
+            ["Assets/Scripts/UI/FriendSlopUI.BuildUi.cs"] = 518,
+            ["Assets/Scripts/UI/FriendSlopUI.cs"] = 496,
+            ["Assets/Scripts/Hazards/RoamingMonster.cs"] = 489,
+        };
+
+        private static readonly HashSet<string> AllowedSingletons = new()
+        {
+            "Assets/Scripts/Round/RoundManager.cs::Instance",
+            "Assets/Scripts/UI/FriendSlopUI.cs::Instance",
+            "Assets/Scripts/Networking/NetworkSessionManager.cs::Instance",
+            "Assets/Scripts/SceneManagement/NetworkSceneTransitionService.cs::Instance",
+            "Assets/Scripts/Player/NetworkFirstPersonController.cs::LocalPlayer",
+        };
+
+        private static readonly string[] BannedPerFrameSearchCalls =
+        {
+            "FindObjectsByType",
+            "FindFirstObjectByType",
+            "FindObjectOfType",
+        };
+
+        private static readonly Regex SingletonDeclarationPattern = new(
+            @"\b(?:public|internal|private|protected)\s+static\s+(?!event\b)[A-Za-z0-9_<>,\.\[\]\s]+\s+(?<name>Instance|LocalPlayer)\b",
+            RegexOptions.Compiled);
+
+        private static readonly Regex FrameMethodPattern = new(
+            @"\b(?:public|internal|private|protected)?\s*(?:async\s+)?void\s+(?<name>Update|FixedUpdate|LateUpdate)\s*\(\s*\)",
+            RegexOptions.Compiled);
+
+        [Test]
+        public void NoNewSingletonStyleGlobals()
+        {
+            var actual = new HashSet<string>();
+
+            foreach (var path in RuntimeScriptPaths())
+            {
+                var text = File.ReadAllText(path);
+                var relative = ToProjectPath(path);
+                foreach (Match match in SingletonDeclarationPattern.Matches(text))
+                {
+                    actual.Add($"{relative}::{match.Groups["name"].Value}");
+                }
+            }
+
+            var unexpected = actual.Except(AllowedSingletons).OrderBy(item => item).ToArray();
+            Assert.IsEmpty(unexpected,
+                "New singleton-style globals need an explicit architecture review. Unexpected declarations:\n  - "
+                + string.Join("\n  - ", unexpected));
+        }
+
+        [Test]
+        public void RuntimeFilesStayUnderLineLimitOrDoNotGrowPastBaseline()
+        {
+            var failures = new List<string>();
+
+            foreach (var path in RuntimeScriptPaths())
+            {
+                var relative = ToProjectPath(path);
+                var actualLines = File.ReadLines(path).Count();
+                var limit = ExistingOversizedRuntimeFiles.TryGetValue(relative, out var baseline)
+                    ? baseline
+                    : DefaultRuntimeFileLineLimit;
+
+                if (actualLines > limit)
+                {
+                    var reason = baseline > 0
+                        ? $"existing oversized baseline is {baseline}; split before adding more"
+                        : $"limit is {DefaultRuntimeFileLineLimit}";
+                    failures.Add($"{relative}: {actualLines} lines ({reason}).");
+                }
+            }
+
+            Assert.IsEmpty(failures,
+                "Runtime files must stay small enough for feature agents to reason about:\n  - "
+                + string.Join("\n  - ", failures));
+        }
+
+        [Test]
+        public void FrameMethodsDoNotSearchSceneObjects()
+        {
+            var failures = new List<string>();
+
+            foreach (var path in RuntimeScriptPaths())
+            {
+                var source = StripComments(File.ReadAllText(path));
+                var relative = ToProjectPath(path);
+
+                foreach (Match match in FrameMethodPattern.Matches(source))
+                {
+                    var methodBody = TryReadMethodBody(source, match.Index);
+                    if (methodBody == null) continue;
+
+                    for (var i = 0; i < BannedPerFrameSearchCalls.Length; i++)
+                    {
+                        var call = BannedPerFrameSearchCalls[i];
+                        if (!methodBody.Contains(call)) continue;
+
+                        var line = CountLinesBefore(source, match.Index);
+                        failures.Add($"{relative}:{line} {match.Groups["name"].Value} contains {call}; cache or use a registry.");
+                    }
+                }
+            }
+
+            Assert.IsEmpty(failures,
+                "Per-frame scene searches are not allowed in runtime code:\n  - "
+                + string.Join("\n  - ", failures));
+        }
+
+        [Test]
+        public void AsmdefReferencesKeepRuntimeAndUiDirectionClean()
+        {
+            var runtimeRefs = ReadAsmdefReferences("Assets/Scripts/FriendSlop.Runtime.asmdef");
+            Assert.IsFalse(runtimeRefs.Contains("FriendSlop.UI"), "Runtime assembly must not reference UI.");
+            Assert.IsFalse(runtimeRefs.Contains("FriendSlop.Editor"), "Runtime assembly must not reference Editor.");
+
+            var uiRefs = ReadAsmdefReferences("Assets/Scripts/UI/FriendSlop.UI.asmdef");
+            Assert.IsFalse(uiRefs.Contains("FriendSlop.Editor"), "UI assembly must not reference Editor.");
+        }
+
+        [Test]
+        public void EditorAssemblyRemainsEditorOnly()
+        {
+            var editorAsmdef = File.ReadAllText(ProjectPath("Assets/Scripts/Editor/FriendSlop.Editor.asmdef"));
+            StringAssert.Contains("\"includePlatforms\"", editorAsmdef);
+            StringAssert.Contains("\"Editor\"", editorAsmdef);
+        }
+
+        private static IEnumerable<string> RuntimeScriptPaths()
+        {
+            var scriptsRoot = ProjectPath("Assets/Scripts");
+            return Directory.GetFiles(scriptsRoot, "*.cs", SearchOption.AllDirectories)
+                .Select(NormalizePath)
+                .Where(path => !path.Contains("/Editor/"))
+                .OrderBy(path => path);
+        }
+
+        private static HashSet<string> ReadAsmdefReferences(string relativePath)
+        {
+            var text = File.ReadAllText(ProjectPath(relativePath));
+            var references = Regex.Match(text, @"""references""\s*:\s*\[(?<refs>.*?)\]", RegexOptions.Singleline);
+            if (!references.Success) return new HashSet<string>();
+
+            return Regex.Matches(references.Groups["refs"].Value, @"""(?<ref>[^""]+)""")
+                .Cast<Match>()
+                .Select(match => match.Groups["ref"].Value)
+                .ToHashSet();
+        }
+
+        private static string TryReadMethodBody(string source, int methodIndex)
+        {
+            var openBrace = source.IndexOf('{', methodIndex);
+            if (openBrace < 0) return null;
+
+            var depth = 0;
+            for (var i = openBrace; i < source.Length; i++)
+            {
+                if (source[i] == '{') depth++;
+                else if (source[i] == '}') depth--;
+
+                if (depth == 0)
+                    return source.Substring(openBrace, i - openBrace + 1);
+            }
+
+            return null;
+        }
+
+        private static string StripComments(string source)
+        {
+            source = Regex.Replace(source, @"/\*.*?\*/",
+                match => new string('\n', match.Value.Count(c => c == '\n')),
+                RegexOptions.Singleline);
+            return Regex.Replace(source, @"//.*", string.Empty);
+        }
+
+        private static int CountLinesBefore(string source, int index)
+        {
+            var line = 1;
+            for (var i = 0; i < index && i < source.Length; i++)
+            {
+                if (source[i] == '\n') line++;
+            }
+            return line;
+        }
+
+        private static string ProjectPath(string relativePath)
+        {
+            return NormalizePath(Path.Combine(ProjectRoot, relativePath));
+        }
+
+        private static string ToProjectPath(string absolutePath)
+        {
+            var normalized = NormalizePath(absolutePath);
+            var root = ProjectRoot + "/";
+            return normalized.StartsWith(root)
+                ? normalized.Substring(root.Length)
+                : normalized;
+        }
+
+        private static string ProjectRoot => NormalizePath(Path.GetFullPath(Path.Combine(Application.dataPath, "..")));
+
+        private static string NormalizePath(string path)
+        {
+            return path.Replace('\\', '/');
+        }
+    }
+}

--- a/Space Game/Assets/Tests/EditMode/Editor/ArchitectureGuardrailTests.cs
+++ b/Space Game/Assets/Tests/EditMode/Editor/ArchitectureGuardrailTests.cs
@@ -26,9 +26,6 @@ namespace FriendSlop.Tests.EditMode
         private static readonly HashSet<string> AllowedSingletons = new()
         {
             "Assets/Scripts/Round/RoundManager.cs::Instance",
-            "Assets/Scripts/UI/FriendSlopUI.cs::Instance",
-            "Assets/Scripts/Networking/NetworkSessionManager.cs::Instance",
-            "Assets/Scripts/SceneManagement/NetworkSceneTransitionService.cs::Instance",
             "Assets/Scripts/Player/NetworkFirstPersonController.cs::LocalPlayer",
         };
 

--- a/Space Game/Assets/Tests/EditMode/Editor/ArchitectureGuardrailTests.cs.meta
+++ b/Space Game/Assets/Tests/EditMode/Editor/ArchitectureGuardrailTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: e55cfd842d824c5e8f9bff96bf3c35df

--- a/Space Game/Assets/Tests/EditMode/Editor/CarrySurfaceUtilityTests.cs
+++ b/Space Game/Assets/Tests/EditMode/Editor/CarrySurfaceUtilityTests.cs
@@ -1,0 +1,75 @@
+using System.Reflection;
+using FriendSlop.Core;
+using NUnit.Framework;
+using UnityEngine;
+
+namespace FriendSlop.Tests.EditMode
+{
+    public class CarrySurfaceUtilityTests
+    {
+        private GameObject worldObject;
+        private GameObject volumeObject;
+
+        [TearDown]
+        public void TearDown()
+        {
+            if (volumeObject != null)
+            {
+                var volume = volumeObject.GetComponent<FlatGravityVolume>();
+                if (volume != null) InvokeLifecycle(volume, "OnDisable");
+                Object.DestroyImmediate(volumeObject);
+                volumeObject = null;
+            }
+
+            if (worldObject != null)
+            {
+                var world = worldObject.GetComponent<SphereWorld>();
+                if (world != null) InvokeLifecycle(world, "OnDisable");
+                Object.DestroyImmediate(worldObject);
+                worldObject = null;
+            }
+        }
+
+        [Test]
+        public void ClampTargetAboveSurface_PushesUndergroundTargetToSurfaceClearance()
+        {
+            var world = CreateWorld(new Vector3(1000f, 0f, 0f));
+            var undergroundPosition = world.Center + Vector3.right * (world.Radius - 2f);
+
+            var clamped = CarrySurfaceUtility.ClampTargetAboveSurface(undergroundPosition);
+
+            Assert.GreaterOrEqual(world.GetSurfaceDistance(clamped), 0.09f);
+            Assert.Less(Vector3.Distance(world.GetUp(undergroundPosition), world.GetUp(clamped)), 0.001f);
+        }
+
+        [Test]
+        public void ClampTargetAboveSurface_LeavesFlatGravityVolumeTargetUnchanged()
+        {
+            var world = CreateWorld(new Vector3(2000f, 0f, 0f));
+            var target = world.Center + Vector3.right * (world.Radius - 2f);
+            volumeObject = new GameObject("Flat Gravity Volume");
+            volumeObject.transform.position = target;
+            InvokeLifecycle(volumeObject.AddComponent<FlatGravityVolume>(), "OnEnable");
+
+            var clamped = CarrySurfaceUtility.ClampTargetAboveSurface(target);
+
+            Assert.AreEqual(target, clamped);
+        }
+
+        private SphereWorld CreateWorld(Vector3 center)
+        {
+            worldObject = new GameObject("Sphere World");
+            worldObject.transform.position = center;
+            var world = worldObject.AddComponent<SphereWorld>();
+            InvokeLifecycle(world, "OnEnable");
+            return world;
+        }
+
+        private static void InvokeLifecycle(MonoBehaviour component, string methodName)
+        {
+            component.GetType()
+                .GetMethod(methodName, BindingFlags.Instance | BindingFlags.NonPublic)
+                ?.Invoke(component, null);
+        }
+    }
+}

--- a/Space Game/Assets/Tests/EditMode/Editor/CarrySurfaceUtilityTests.cs.meta
+++ b/Space Game/Assets/Tests/EditMode/Editor/CarrySurfaceUtilityTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 98aecd0d16fa4df08f2d50086623fd3e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Space Game/Assets/Tests/EditMode/Editor/FriendSlop.EditModeTests.asmdef
+++ b/Space Game/Assets/Tests/EditMode/Editor/FriendSlop.EditModeTests.asmdef
@@ -3,6 +3,7 @@
     "rootNamespace": "FriendSlop.Tests.EditMode",
     "references": [
         "FriendSlop.Runtime",
+        "Unity.Netcode.Runtime",
         "Unity.Services.Core",
         "Unity.Services.Multiplayer"
     ],

--- a/Space Game/Assets/Tests/EditMode/Editor/FriendSlop.EditModeTests.asmdef
+++ b/Space Game/Assets/Tests/EditMode/Editor/FriendSlop.EditModeTests.asmdef
@@ -2,6 +2,7 @@
     "name": "FriendSlop.EditModeTests",
     "rootNamespace": "FriendSlop.Tests.EditMode",
     "references": [
+        "FriendSlop.Editor",
         "FriendSlop.Runtime",
         "Unity.Netcode.Runtime",
         "Unity.Services.Core",

--- a/Space Game/Assets/Tests/EditMode/Editor/NetworkLootItemCarrierCacheTests.cs
+++ b/Space Game/Assets/Tests/EditMode/Editor/NetworkLootItemCarrierCacheTests.cs
@@ -1,0 +1,89 @@
+using System.Reflection;
+using FriendSlop.Loot;
+using FriendSlop.Player;
+using NUnit.Framework;
+using UnityEngine;
+
+namespace FriendSlop.Tests.EditMode
+{
+    public class NetworkLootItemCarrierCacheTests
+    {
+        private GameObject playerObject;
+        private GameObject itemObject;
+
+        [TearDown]
+        public void TearDown()
+        {
+            NetworkFirstPersonController.ActivePlayers.Clear();
+
+            if (itemObject != null)
+            {
+                Object.DestroyImmediate(itemObject);
+                itemObject = null;
+            }
+
+            if (playerObject != null)
+            {
+                Object.DestroyImmediate(playerObject);
+                playerObject = null;
+            }
+        }
+
+        [Test]
+        public void OnCarrierChanged_CachesAndClearsCarrierReference()
+        {
+            const ulong clientId = 42UL;
+            var player = CreatePlayer(clientId);
+            var item = CreateLootItem();
+            item.SlotIndex.Value = 0;
+
+            InvokeCarrierChanged(item, ulong.MaxValue, clientId);
+
+            Assert.AreSame(player, GetCachedCarrier(item));
+
+            InvokeCarrierChanged(item, clientId, ulong.MaxValue);
+
+            Assert.IsNull(GetCachedCarrier(item));
+        }
+
+        private NetworkFirstPersonController CreatePlayer(ulong clientId)
+        {
+            playerObject = new GameObject("Carrier");
+            var player = playerObject.AddComponent<NetworkFirstPersonController>();
+            typeof(NetworkFirstPersonController)
+                .GetProperty("OwnerClientId")
+                ?.SetValue(player, clientId);
+            NetworkFirstPersonController.ActivePlayers.Add(player);
+            return player;
+        }
+
+        private NetworkLootItem CreateLootItem()
+        {
+            itemObject = new GameObject("Loot");
+            var item = itemObject.AddComponent<NetworkLootItem>();
+            InvokeLifecycle(item, "Awake");
+            return item;
+        }
+
+        private static void InvokeCarrierChanged(NetworkLootItem item, ulong previousCarrier, ulong currentCarrier)
+        {
+            typeof(NetworkLootItem)
+                .GetMethod("OnCarrierChanged", BindingFlags.Instance | BindingFlags.NonPublic)
+                ?.Invoke(item, new object[] { previousCarrier, currentCarrier });
+        }
+
+        private static NetworkFirstPersonController GetCachedCarrier(NetworkLootItem item)
+        {
+            return (NetworkFirstPersonController)typeof(NetworkLootItem)
+                .GetField("_cachedCarrier", BindingFlags.Instance | BindingFlags.NonPublic)
+                ?.GetValue(item);
+        }
+
+        private static void InvokeLifecycle(MonoBehaviour component, string methodName)
+        {
+            component.GetType()
+                .GetMethod(methodName, BindingFlags.Instance | BindingFlags.NonPublic)
+                ?.Invoke(component, null);
+        }
+    }
+}

--- a/Space Game/Assets/Tests/EditMode/Editor/NetworkLootItemCarrierCacheTests.cs.meta
+++ b/Space Game/Assets/Tests/EditMode/Editor/NetworkLootItemCarrierCacheTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 43da3b34048046188e9eb402a7c2d7f5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Space Game/Assets/Tests/EditMode/Editor/NetworkLootItemDeclarationOrderTests.cs
+++ b/Space Game/Assets/Tests/EditMode/Editor/NetworkLootItemDeclarationOrderTests.cs
@@ -1,0 +1,30 @@
+using System.Linq;
+using System.Reflection;
+using FriendSlop.Loot;
+using NUnit.Framework;
+using Unity.Netcode;
+
+namespace FriendSlop.Tests.EditMode
+{
+    public class NetworkLootItemDeclarationOrderTests
+    {
+        [Test]
+        public void NetworkLootItem_SlotIndex_DeclaredBefore_CarrierClientId()
+        {
+            var fields = typeof(NetworkLootItem)
+                .GetFields(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)
+                .Where(field => field.FieldType.IsGenericType
+                    && field.FieldType.GetGenericTypeDefinition() == typeof(NetworkVariable<>))
+                .OrderBy(field => field.MetadataToken)
+                .ToList();
+
+            var slotIndex = fields.FindIndex(field => field.Name == nameof(NetworkLootItem.SlotIndex));
+            var carrierClientId = fields.FindIndex(field => field.Name == nameof(NetworkLootItem.CarrierClientId));
+
+            Assert.GreaterOrEqual(slotIndex, 0, "SlotIndex must remain a NetworkVariable on NetworkLootItem.");
+            Assert.GreaterOrEqual(carrierClientId, 0, "CarrierClientId must remain a NetworkVariable on NetworkLootItem.");
+            Assert.Greater(carrierClientId, slotIndex,
+                "SlotIndex must be declared before CarrierClientId. NGO deserializes NetworkVariables in declaration order; OnCarrierChanged reads SlotIndex.Value.");
+        }
+    }
+}

--- a/Space Game/Assets/Tests/EditMode/Editor/NetworkLootItemDeclarationOrderTests.cs.meta
+++ b/Space Game/Assets/Tests/EditMode/Editor/NetworkLootItemDeclarationOrderTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e8c499ca87684f8f945e516b9a376901
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Space Game/Assets/Tests/EditMode/Editor/PlanetCatalogBuildSettingsTests.cs
+++ b/Space Game/Assets/Tests/EditMode/Editor/PlanetCatalogBuildSettingsTests.cs
@@ -1,12 +1,6 @@
 using System.Collections.Generic;
-using System.IO;
-using FriendSlop.Round;
-using FriendSlop.SceneManagement;
+using FriendSlop.Editor;
 using NUnit.Framework;
-using UnityEditor;
-using UnityEditor.SceneManagement;
-using UnityEngine;
-using UnityEngine.SceneManagement;
 
 namespace FriendSlop.Tests.EditMode
 {
@@ -19,279 +13,41 @@ namespace FriendSlop.Tests.EditMode
         [Test]
         public void EveryCatalogPlanetWithScene_PointsAtBuildSettingsEntry()
         {
-            var failures = new List<string>();
-            var buildScenes = LoadBuildSettingsScenePaths();
-
-            foreach (var catalog in LoadAllAssets<PlanetCatalog>())
-            {
-                if (catalog == null || catalog.AllPlanets == null) continue;
-
-                for (var i = 0; i < catalog.AllPlanets.Count; i++)
-                {
-                    var planet = catalog.AllPlanets[i];
-                    if (planet == null || !planet.HasPlanetScene) continue;
-
-                    var scenePath = planet.PlanetScene.ScenePath;
-                    var label = $"{catalog.name} -> {planet.name} -> {planet.PlanetScene.name}";
-
-                    if (!File.Exists(scenePath))
-                    {
-                        failures.Add($"{label}: scene file does not exist at '{scenePath}'.");
-                        continue;
-                    }
-
-                    if (!buildScenes.TryGetValue(scenePath, out var enabled))
-                    {
-                        failures.Add($"{label}: scene '{scenePath}' is not in EditorBuildSettings.");
-                        continue;
-                    }
-
-                    if (!enabled)
-                    {
-                        failures.Add($"{label}: scene '{scenePath}' is in EditorBuildSettings but disabled.");
-                    }
-                }
-            }
-
-            if (failures.Count > 0)
-            {
-                Assert.Fail("Planet scene wiring is out of sync with Build Settings:\n  - "
-                    + string.Join("\n  - ", failures));
-            }
+            AssertNoFailures(
+                PlanetSceneValidator.ValidateCatalogPlanetScenesInBuildSettings,
+                "Planet scene wiring is out of sync with Build Settings");
         }
 
         [Test]
         public void EverySceneCatalogPlanetEntry_PointsAtBuildSettingsEntry()
         {
-            var failures = new List<string>();
-            var buildScenes = LoadBuildSettingsScenePaths();
-
-            foreach (var catalog in LoadAllAssets<GameSceneCatalog>())
-            {
-                if (catalog == null || catalog.AllScenes == null) continue;
-
-                for (var i = 0; i < catalog.AllScenes.Count; i++)
-                {
-                    var def = catalog.AllScenes[i];
-                    if (def == null || def.Role != GameSceneRole.Planet) continue;
-                    if (!def.IsConfigured) continue;
-
-                    var scenePath = def.ScenePath;
-                    var label = $"{catalog.name} -> {def.name}";
-
-                    if (!File.Exists(scenePath))
-                    {
-                        failures.Add($"{label}: scene file does not exist at '{scenePath}'.");
-                        continue;
-                    }
-
-                    if (!buildScenes.TryGetValue(scenePath, out var enabled))
-                    {
-                        failures.Add($"{label}: scene '{scenePath}' is not in EditorBuildSettings.");
-                        continue;
-                    }
-
-                    if (!enabled)
-                    {
-                        failures.Add($"{label}: scene '{scenePath}' is in EditorBuildSettings but disabled.");
-                    }
-                }
-            }
-
-            if (failures.Count > 0)
-            {
-                Assert.Fail("Scene catalog Planet entries are out of sync with Build Settings:\n  - "
-                    + string.Join("\n  - ", failures));
-            }
+            AssertNoFailures(
+                PlanetSceneValidator.ValidateSceneCatalogPlanetEntriesInBuildSettings,
+                "Scene catalog Planet entries are out of sync with Build Settings");
         }
 
         [Test]
         public void EveryCatalogPlanetWithScene_HasRoundReadyEnvironment()
         {
-            var failures = new List<string>();
-
-            foreach (var catalog in LoadAllAssets<PlanetCatalog>())
-            {
-                if (catalog == null || catalog.AllPlanets == null) continue;
-
-                for (var i = 0; i < catalog.AllPlanets.Count; i++)
-                {
-                    var planet = catalog.AllPlanets[i];
-                    if (planet == null || !planet.HasPlanetScene) continue;
-
-                    WithScene(planet.PlanetScene.ScenePath, scene =>
-                    {
-                        var environments = GetComponentsInScene<PlanetEnvironment>(scene);
-                        var environment = FindCompatibleEnvironment(environments, planet);
-                        var label = $"{catalog.name} -> {planet.name} -> {planet.PlanetScene.name}";
-
-                        if (environment == null)
-                        {
-                            failures.Add($"{label}: no compatible PlanetEnvironment was found.");
-                            return;
-                        }
-
-                        if (environment.LaunchpadZone == null)
-                            failures.Add($"{label}: PlanetEnvironment '{environment.name}' has no LaunchpadZone assigned.");
-
-                        if (!HasAnyLiveTransform(environment.PlayerSpawnPoints))
-                            failures.Add($"{label}: PlanetEnvironment '{environment.name}' has no live player spawn points.");
-
-                        if (!HasTeleporterToShip(scene))
-                            failures.Add($"{label}: scene has no TeleporterPad targeting Ship.");
-                    });
-                }
-            }
-
-            if (failures.Count > 0)
-            {
-                Assert.Fail("Planet scenes are not round-ready:\n  - "
-                    + string.Join("\n  - ", failures));
-            }
+            AssertNoFailures(
+                PlanetSceneValidator.ValidateCatalogPlanetScenesRoundReady,
+                "Planet scenes are not round-ready");
         }
 
         [Test]
         public void BootstrapScene_HasShipTeleporterToActivePlanet()
         {
-            const string bootstrapScenePath = "Assets/Scenes/FriendSlopPrototype.unity";
-            if (!File.Exists(bootstrapScenePath))
-                Assert.Fail($"Bootstrap scene does not exist at '{bootstrapScenePath}'.");
-
-            WithScene(bootstrapScenePath, scene =>
-            {
-                Assert.IsTrue(HasTeleporterToActivePlanet(scene),
-                    "The bootstrap ship scene should include a TeleporterPad targeting ActivePlanet.");
-            });
+            AssertNoFailures(
+                PlanetSceneValidator.ValidateBootstrapShipTeleporter,
+                "Bootstrap scene teleporter wiring is invalid");
         }
 
-        private static Dictionary<string, bool> LoadBuildSettingsScenePaths()
+        private static void AssertNoFailures(System.Action<List<string>> validate, string message)
         {
-            var result = new Dictionary<string, bool>(System.StringComparer.OrdinalIgnoreCase);
-            var scenes = EditorBuildSettings.scenes;
-            for (var i = 0; i < scenes.Length; i++)
-            {
-                var entry = scenes[i];
-                if (entry == null || string.IsNullOrEmpty(entry.path)) continue;
-                var normalized = GameScenePathUtility.NormalizePath(entry.path);
-                // Last write wins on duplicates. That is fine here because the validation
-                // only needs to catch a scene missing from build settings or disabled there.
-                result[normalized] = entry.enabled;
-            }
-            return result;
-        }
-
-        private static IEnumerable<T> LoadAllAssets<T>() where T : UnityEngine.Object
-        {
-            var guids = AssetDatabase.FindAssets("t:" + typeof(T).Name);
-            foreach (var guid in guids)
-            {
-                var path = AssetDatabase.GUIDToAssetPath(guid);
-                var asset = AssetDatabase.LoadAssetAtPath<T>(path);
-                if (asset != null) yield return asset;
-            }
-        }
-
-        private static void WithScene(string scenePath, System.Action<Scene> inspect)
-        {
-            var setup = EditorSceneManager.GetSceneManagerSetup();
-            Scene scene = default;
-            try
-            {
-                scene = EditorSceneManager.OpenScene(scenePath, OpenSceneMode.Additive);
-                inspect(scene);
-            }
-            finally
-            {
-                if (!TryRestoreSceneSetup(setup))
-                {
-                    if (scene.IsValid() && scene.isLoaded)
-                        EditorSceneManager.CloseScene(scene, true);
-                    EditorSceneManager.NewScene(NewSceneSetup.EmptyScene, NewSceneMode.Single);
-                }
-            }
-        }
-
-        private static bool TryRestoreSceneSetup(SceneSetup[] setup)
-        {
-            if (setup == null || setup.Length == 0)
-                return false;
-
-            try
-            {
-                EditorSceneManager.RestoreSceneManagerSetup(setup);
-                return true;
-            }
-            catch (System.ArgumentException)
-            {
-                return false;
-            }
-        }
-
-        private static T[] GetComponentsInScene<T>(Scene scene) where T : Component
-        {
-            var results = new List<T>();
-            var roots = scene.GetRootGameObjects();
-            for (var i = 0; i < roots.Length; i++)
-            {
-                results.AddRange(roots[i].GetComponentsInChildren<T>(true));
-            }
-            return results.ToArray();
-        }
-
-        private static PlanetEnvironment FindCompatibleEnvironment(PlanetEnvironment[] environments, PlanetDefinition planet)
-        {
-            if (environments == null || planet == null) return null;
-
-            for (var i = 0; i < environments.Length; i++)
-            {
-                var env = environments[i];
-                if (env != null && env.Planet == planet)
-                    return env;
-            }
-
-            // Current tier 2 variants intentionally share one Rusty Moon scene. Runtime
-            // binding allows same-tier environments as that fallback, so validation does too.
-            for (var i = 0; i < environments.Length; i++)
-            {
-                var env = environments[i];
-                if (env != null && env.Planet != null && env.Planet.Tier == planet.Tier)
-                    return env;
-            }
-
-            return null;
-        }
-
-        private static bool HasAnyLiveTransform(Transform[] transforms)
-        {
-            if (transforms == null) return false;
-            for (var i = 0; i < transforms.Length; i++)
-            {
-                if (transforms[i] != null)
-                    return true;
-            }
-            return false;
-        }
-
-        private static bool HasTeleporterToShip(Scene scene)
-        {
-            var pads = GetComponentsInScene<TeleporterPad>(scene);
-            for (var i = 0; i < pads.Length; i++)
-            {
-                if (pads[i] != null && pads[i].Destination == TeleporterTarget.Ship)
-                    return true;
-            }
-            return false;
-        }
-
-        private static bool HasTeleporterToActivePlanet(Scene scene)
-        {
-            var pads = GetComponentsInScene<TeleporterPad>(scene);
-            for (var i = 0; i < pads.Length; i++)
-            {
-                if (pads[i] != null && pads[i].Destination == TeleporterTarget.ActivePlanet)
-                    return true;
-            }
-            return false;
+            var failures = new List<string>();
+            validate(failures);
+            if (failures.Count > 0)
+                Assert.Fail(message + ":\n  - " + string.Join("\n  - ", failures));
         }
     }
 }

--- a/Space Game/Assets/Tests/EditMode/Editor/PlanetSceneOrchestratorTests.cs
+++ b/Space Game/Assets/Tests/EditMode/Editor/PlanetSceneOrchestratorTests.cs
@@ -1,0 +1,37 @@
+using System.Reflection;
+using FriendSlop.Round;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace FriendSlop.Tests.EditMode
+{
+    public class PlanetSceneOrchestratorTests
+    {
+        [Test]
+        public void MissingPlanetScenePath_LogsWarningOnce()
+        {
+            const string missingScenePath = "Assets/Scenes/DefinitelyMissingPlanetScene.unity";
+            var orchestratorObject = new GameObject("Planet Scene Orchestrator Test");
+            try
+            {
+                var orchestrator = orchestratorObject.AddComponent<PlanetSceneOrchestrator>();
+                var warnMethod = typeof(PlanetSceneOrchestrator).GetMethod("WarnMissingPlanetSceneIfNeeded",
+                    BindingFlags.NonPublic | BindingFlags.Instance);
+
+                Assert.IsNotNull(warnMethod, "Expected a testable missing-scene warning path.");
+                LogAssert.Expect(LogType.Warning,
+                    $"RoundManager: planet scene '{missingScenePath}' is not in Build Settings; skipping additive load. " +
+                    "(Run Tools/Friend Slop/Extract Tier 1 Into Scene to author it.)");
+
+                Assert.IsTrue((bool)warnMethod.Invoke(orchestrator, new object[] { missingScenePath }));
+                Assert.IsTrue((bool)warnMethod.Invoke(orchestrator, new object[] { missingScenePath }));
+                LogAssert.NoUnexpectedReceived();
+            }
+            finally
+            {
+                Object.DestroyImmediate(orchestratorObject);
+            }
+        }
+    }
+}

--- a/Space Game/Assets/Tests/EditMode/Editor/PlanetSceneOrchestratorTests.cs.meta
+++ b/Space Game/Assets/Tests/EditMode/Editor/PlanetSceneOrchestratorTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: f424856d4b9d45b3be4fe139620e05e5

--- a/Space Game/Assets/Tests/EditMode/Editor/PlanetSceneValidatorTests.cs
+++ b/Space Game/Assets/Tests/EditMode/Editor/PlanetSceneValidatorTests.cs
@@ -1,0 +1,16 @@
+using FriendSlop.Editor;
+using NUnit.Framework;
+
+namespace FriendSlop.Tests.EditMode
+{
+    public class PlanetSceneValidatorTests
+    {
+        [Test]
+        public void CurrentPlanetScenes_PassValidation()
+        {
+            Assert.IsTrue(
+                PlanetSceneValidator.TryValidate(out var failures),
+                "Planet scene validation failed:\n  - " + string.Join("\n  - ", failures));
+        }
+    }
+}

--- a/Space Game/Assets/Tests/EditMode/Editor/PlanetSceneValidatorTests.cs.meta
+++ b/Space Game/Assets/Tests/EditMode/Editor/PlanetSceneValidatorTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 8ff2f6a245034d98b7995e70ae1ef0a3

--- a/Space Game/Assets/Tests/EditMode/Editor/RoundManagerPrefabWiringTests.cs
+++ b/Space Game/Assets/Tests/EditMode/Editor/RoundManagerPrefabWiringTests.cs
@@ -1,0 +1,30 @@
+using FriendSlop.Round;
+using NUnit.Framework;
+using UnityEditor;
+using UnityEngine;
+
+namespace FriendSlop.Tests.EditMode
+{
+    public class RoundManagerPrefabWiringTests
+    {
+        private const string RoundManagerPrefabPath = "Assets/Prefabs/RoundManager.prefab";
+
+        [Test]
+        public void RoundManagerPrefab_WiresPlanetSceneOrchestrator()
+        {
+            var prefab = AssetDatabase.LoadAssetAtPath<GameObject>(RoundManagerPrefabPath);
+            Assert.IsNotNull(prefab, $"Expected RoundManager prefab at {RoundManagerPrefabPath}.");
+
+            var round = prefab.GetComponent<RoundManager>();
+            var orchestrator = prefab.GetComponent<PlanetSceneOrchestrator>();
+            Assert.IsNotNull(round, "RoundManager prefab should include RoundManager.");
+            Assert.IsNotNull(orchestrator, "RoundManager prefab should include PlanetSceneOrchestrator.");
+
+            var serializedRound = new SerializedObject(round);
+            var property = serializedRound.FindProperty("planetSceneOrchestrator");
+            Assert.IsNotNull(property, "RoundManager should expose a serialized planetSceneOrchestrator field.");
+            Assert.AreSame(orchestrator, property.objectReferenceValue,
+                "RoundManager should delegate planet scene loading to the orchestrator on the same prefab.");
+        }
+    }
+}

--- a/Space Game/Assets/Tests/EditMode/Editor/RoundManagerPrefabWiringTests.cs.meta
+++ b/Space Game/Assets/Tests/EditMode/Editor/RoundManagerPrefabWiringTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 47c1819bc01244da8483c48f9a5da41b

--- a/Space Game/Assets/Tests/EditMode/Editor/RoundObjectiveTextTests.cs
+++ b/Space Game/Assets/Tests/EditMode/Editor/RoundObjectiveTextTests.cs
@@ -1,0 +1,79 @@
+using FriendSlop.Round;
+using NUnit.Framework;
+using UnityEngine;
+
+namespace FriendSlop.Tests.EditMode
+{
+    public class RoundObjectiveTextTests
+    {
+        [Test]
+        public void QuotaObjective_ResultText_ReportsCollectedAgainstTarget()
+        {
+            var roundObject = new GameObject("Round Manager Text Test");
+            var objective = ScriptableObject.CreateInstance<QuotaObjective>();
+            try
+            {
+                var round = roundObject.AddComponent<RoundManager>();
+                round.Quota.Value = 500;
+
+                round.CollectedValue.Value = 600;
+                StringAssert.Contains("QUOTA MET", objective.BuildSuccessText(round));
+
+                round.CollectedValue.Value = 450;
+                StringAssert.Contains("Collected $450 / $500", objective.BuildFailureText(round));
+            }
+            finally
+            {
+                Object.DestroyImmediate(objective);
+                Object.DestroyImmediate(roundObject);
+            }
+        }
+
+        [Test]
+        public void RocketAssemblyObjective_FailureText_ListsPartProgress()
+        {
+            var roundObject = new GameObject("Round Manager Text Test");
+            var objective = ScriptableObject.CreateInstance<RocketAssemblyObjective>();
+            try
+            {
+                var round = roundObject.AddComponent<RoundManager>();
+                round.HasCockpit.Value = true;
+                round.HasWings.Value = false;
+                round.HasEngine.Value = false;
+
+                var text = objective.BuildFailureText(round);
+
+                StringAssert.Contains("ROCKET NOT READY", text);
+                StringAssert.Contains("Cockpit OK", text);
+                StringAssert.Contains("Wings missing", text);
+                StringAssert.Contains("Engine missing", text);
+            }
+            finally
+            {
+                Object.DestroyImmediate(objective);
+                Object.DestroyImmediate(roundObject);
+            }
+        }
+
+        [Test]
+        public void SurvivalObjective_SuccessText_UsesSurvivalCopy()
+        {
+            var roundObject = new GameObject("Round Manager Text Test");
+            var objective = ScriptableObject.CreateInstance<SurvivalObjective>();
+            try
+            {
+                var round = roundObject.AddComponent<RoundManager>();
+
+                var text = objective.BuildSuccessText(round);
+
+                StringAssert.Contains("SURVIVED", text);
+                StringAssert.Contains("\nCrew survived", text);
+            }
+            finally
+            {
+                Object.DestroyImmediate(objective);
+                Object.DestroyImmediate(roundObject);
+            }
+        }
+    }
+}

--- a/Space Game/Assets/Tests/EditMode/Editor/RoundObjectiveTextTests.cs.meta
+++ b/Space Game/Assets/Tests/EditMode/Editor/RoundObjectiveTextTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 79b1f770c5d44681b1ec1fbbf50148a1

--- a/Space Game/Assets/Tests/EditMode/Editor/Tier2PlanetVariantTests.cs
+++ b/Space Game/Assets/Tests/EditMode/Editor/Tier2PlanetVariantTests.cs
@@ -1,0 +1,55 @@
+using System.Reflection;
+using FriendSlop.Round;
+using NUnit.Framework;
+using UnityEditor;
+
+namespace FriendSlop.Tests.EditMode
+{
+    public class Tier2PlanetVariantTests
+    {
+        private const string CatalogPath = "Assets/Planets/PlanetCatalog.asset";
+        private const string RustyMoonPath = "Assets/Planets/Tier2_RustyMoon.asset";
+        private const string DeepHaulPath = "Assets/Planets/Tier2_DeepHaul.asset";
+        private const string QuickStrikePath = "Assets/Planets/Tier2_QuickStrike.asset";
+        private const string GhostShiftPath = "Assets/Planets/Tier2_GhostShift.asset";
+        private const string SharedTier2ScenePath = "Assets/Scenes/Planet_RustyMoon.unity";
+
+        [Test]
+        public void Tier2Variants_UseExplicitObjectivesAndSharedRustyMoonScene()
+        {
+            var catalog = AssetDatabase.LoadAssetAtPath<PlanetCatalog>(CatalogPath);
+            var rustyMoon = AssetDatabase.LoadAssetAtPath<PlanetDefinition>(RustyMoonPath);
+            Assert.IsNotNull(catalog, $"Expected planet catalog at {CatalogPath}.");
+            Assert.IsNotNull(rustyMoon, $"Expected shared Tier 2 scene owner at {RustyMoonPath}.");
+            Assert.IsTrue(rustyMoon.HasPlanetScene, "Rusty Moon should own the shared Tier 2 planet scene.");
+            Assert.AreEqual(SharedTier2ScenePath, rustyMoon.PlanetScene.ScenePath);
+
+            AssertVariantUsesSharedScene(catalog, rustyMoon, DeepHaulPath);
+            AssertVariantUsesSharedScene(catalog, rustyMoon, QuickStrikePath);
+            AssertVariantUsesSharedScene(catalog, rustyMoon, GhostShiftPath);
+        }
+
+        private static void AssertVariantUsesSharedScene(PlanetCatalog catalog, PlanetDefinition rustyMoon, string assetPath)
+        {
+            var variant = AssetDatabase.LoadAssetAtPath<PlanetDefinition>(assetPath);
+            Assert.IsNotNull(variant, $"Expected Tier 2 variant at {assetPath}.");
+            Assert.AreEqual(2, variant.Tier, $"{variant.name} should stay in tier 2.");
+            Assert.IsFalse(variant.HasPlanetScene,
+                $"{variant.name} is a mission variant and should fall back to Rusty Moon's shared scene.");
+            Assert.IsNotNull(variant.Objective,
+                $"{variant.name} should declare an explicit objective because it shares scene content.");
+
+            var owner = ResolveSceneOwner(variant, catalog);
+            Assert.AreSame(rustyMoon, owner,
+                $"{variant.name} should resolve to Rusty Moon as its scene owner.");
+        }
+
+        private static PlanetDefinition ResolveSceneOwner(PlanetDefinition planet, PlanetCatalog catalog)
+        {
+            var method = typeof(PlanetSceneOrchestrator).GetMethod("ResolveSceneOwner",
+                BindingFlags.NonPublic | BindingFlags.Static);
+            Assert.IsNotNull(method, "PlanetSceneOrchestrator should expose a private scene-owner resolver.");
+            return (PlanetDefinition)method.Invoke(null, new object[] { planet, catalog });
+        }
+    }
+}

--- a/Space Game/Assets/Tests/EditMode/Editor/Tier2PlanetVariantTests.cs.meta
+++ b/Space Game/Assets/Tests/EditMode/Editor/Tier2PlanetVariantTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 51fa3da7845b4047b7d88fe03bba7680

--- a/Space Game/Assets/Tests/PlayMode/FriendSlopPrototypeSmokeTests.cs
+++ b/Space Game/Assets/Tests/PlayMode/FriendSlopPrototypeSmokeTests.cs
@@ -50,6 +50,8 @@ namespace FriendSlop.Tests.PlayMode
             yield return WaitForActivePlanetSceneLoaded();
             yield return WaitForActivePlanetSpawnsPopulated();
 
+            var activePlanetScene = AssertActivePlanetSceneLoaded();
+            AssertSpawnedActorsInActivePlanetScene(activePlanetScene);
             AssertLaunchpadLayout();
             AssertShipPartSpawnPointsAreNearLaunchpadHemisphere();
 
@@ -132,6 +134,44 @@ namespace FriendSlop.Tests.PlayMode
             if (planet == null) return false;
             var env = PlanetEnvironment.FindFor(planet);
             return env != null && env.gameObject.activeInHierarchy;
+        }
+
+        private static Scene AssertActivePlanetSceneLoaded()
+        {
+            var rm = RoundManager.Instance;
+            Assert.IsNotNull(rm, "RoundManager should exist before validating planet scene ownership.");
+            var planet = rm.CurrentPlanet;
+            Assert.IsNotNull(planet, "RoundManager should have a current planet.");
+            Assert.IsTrue(planet.HasPlanetScene, "The active Tier 1 planet should have a dedicated scene definition.");
+
+            var scene = SceneManager.GetSceneByPath(planet.PlanetScene.ScenePath);
+            Assert.IsTrue(scene.IsValid(), $"Active planet scene should resolve by path '{planet.PlanetScene.ScenePath}'.");
+            Assert.IsTrue(scene.isLoaded, $"Active planet scene '{planet.PlanetScene.ScenePath}' should be loaded additively.");
+
+            var env = PlanetEnvironment.FindFor(planet);
+            Assert.IsNotNull(env, "Active planet scene should register a PlanetEnvironment for the current planet.");
+            Assert.AreEqual(scene.path, env.gameObject.scene.path,
+                "The active planet environment should be owned by the loaded planet scene.");
+            return scene;
+        }
+
+        private static void AssertSpawnedActorsInActivePlanetScene(Scene activePlanetScene)
+        {
+            var lootItems = Object.FindObjectsByType<NetworkLootItem>(FindObjectsInactive.Include, FindObjectsSortMode.None);
+            Assert.Greater(lootItems.Length, 0, "Host startup should spawn loot before validating scene ownership.");
+            foreach (var loot in lootItems)
+            {
+                Assert.AreEqual(activePlanetScene.path, loot.gameObject.scene.path,
+                    $"Loot '{loot.name}' should spawn in the active planet scene, not the bootstrap scene.");
+            }
+
+            var monsters = Object.FindObjectsByType<RoamingMonster>(FindObjectsInactive.Include, FindObjectsSortMode.None);
+            Assert.Greater(monsters.Length, 0, "Host startup should spawn monsters before validating scene ownership.");
+            foreach (var monster in monsters)
+            {
+                Assert.AreEqual(activePlanetScene.path, monster.gameObject.scene.path,
+                    $"Monster '{monster.name}' should spawn in the active planet scene, not the bootstrap scene.");
+            }
         }
 
         private static IEnumerator LoadPrototypeScene()

--- a/Space Game/Assets/Tests/PlayMode/FriendSlopPrototypeSmokeTests.cs
+++ b/Space Game/Assets/Tests/PlayMode/FriendSlopPrototypeSmokeTests.cs
@@ -5,6 +5,7 @@ using FriendSlop.Loot;
 using FriendSlop.Networking;
 using FriendSlop.Player;
 using FriendSlop.Round;
+using FriendSlop.SceneManagement;
 using FriendSlop.Ship;
 using FriendSlop.UI;
 using NUnit.Framework;
@@ -24,8 +25,9 @@ namespace FriendSlop.Tests.PlayMode
 
             Assert.AreEqual("FriendSlopPrototype", SceneManager.GetActiveScene().name);
             Assert.IsNotNull(NetworkManager.Singleton, "NetworkManager should exist in the prototype scene.");
-            Assert.IsNotNull(NetworkSessionManager.Instance, "NetworkSessionManager should exist in the prototype scene.");
-            Assert.IsNotNull(FriendSlopUI.Instance, "FriendSlopUI should exist in the prototype scene.");
+            Assert.IsNotNull(FindSessionManager(), "NetworkSessionManager should exist in the prototype scene.");
+            Assert.IsNotNull(Object.FindAnyObjectByType<FriendSlopUI>(), "FriendSlopUI should exist in the prototype scene.");
+            Assert.IsNotNull(Object.FindAnyObjectByType<NetworkSceneTransitionService>(), "NetworkSceneTransitionService should exist in the prototype scene.");
             Assert.IsNotNull(Object.FindAnyObjectByType<PrototypeNetworkBootstrapper>(), "Prototype bootstrapper should exist in the prototype scene.");
             // Tier 1 launchpad / ship-part assertions used to live here, but the planet now
             // ships in its own additively-loaded scene. They run after host start, once the
@@ -73,7 +75,7 @@ namespace FriendSlop.Tests.PlayMode
             yield return ShutdownAndWaitForSessionCleanup();
 
             Assert.IsFalse(NetworkManager.Singleton.IsListening, "Shutdown should stop the local session.");
-            Assert.AreEqual("Not connected.", NetworkSessionManager.Instance.Status);
+            Assert.AreEqual("Not connected.", FindSessionManager().Status);
             Assert.AreEqual(CursorLockMode.None, Cursor.lockState, "Shutdown should release the cursor back to the UI.");
             Assert.IsTrue(Cursor.visible, "Shutdown should make the cursor visible for UI interaction.");
             Assert.AreEqual(0, Object.FindObjectsByType<RoundManager>(FindObjectsInactive.Include, FindObjectsSortMode.None).Length,
@@ -186,10 +188,16 @@ namespace FriendSlop.Tests.PlayMode
             yield return null;
         }
 
+        private static NetworkSessionManager FindSessionManager()
+        {
+            return Object.FindAnyObjectByType<NetworkSessionManager>();
+        }
+
         private static IEnumerator StartLocalHostAndWaitForRoundManager()
         {
-            Assert.IsNotNull(NetworkSessionManager.Instance, "NetworkSessionManager should exist before host startup.");
-            NetworkSessionManager.Instance.StartLocalHost();
+            var sessionManager = FindSessionManager();
+            Assert.IsNotNull(sessionManager, "NetworkSessionManager should exist before host startup.");
+            sessionManager.StartLocalHost();
 
             for (var frame = 0; frame < 120 && RoundManager.Instance == null; frame++)
             {
@@ -201,8 +209,9 @@ namespace FriendSlop.Tests.PlayMode
 
         private static IEnumerator ShutdownAndWaitForSessionCleanup()
         {
-            Assert.IsNotNull(NetworkSessionManager.Instance, "NetworkSessionManager should exist before shutdown.");
-            NetworkSessionManager.Instance.Shutdown();
+            var sessionManager = FindSessionManager();
+            Assert.IsNotNull(sessionManager, "NetworkSessionManager should exist before shutdown.");
+            sessionManager.Shutdown();
 
             for (var frame = 0; frame < 10; frame++)
             {
@@ -226,17 +235,18 @@ namespace FriendSlop.Tests.PlayMode
 
         private static IEnumerator StartLocalClientAndCancel()
         {
-            Assert.IsNotNull(NetworkSessionManager.Instance, "NetworkSessionManager should exist before client startup.");
-            Assert.IsTrue(NetworkSessionManager.Instance.StartLocalClient("127.0.0.1"),
+            var sessionManager = FindSessionManager();
+            Assert.IsNotNull(sessionManager, "NetworkSessionManager should exist before client startup.");
+            Assert.IsTrue(sessionManager.StartLocalClient("127.0.0.1"),
                 "Starting a LAN client should enter a cancelable connection attempt.");
 
             yield return null;
 
-            Assert.IsTrue(NetworkSessionManager.Instance.CanCancelSessionOperation,
+            Assert.IsTrue(sessionManager.CanCancelSessionOperation,
                 "A pending LAN client connection should be cancelable.");
-            Assert.Greater(NetworkSessionManager.Instance.PendingConnectionSecondsRemaining, 0f,
+            Assert.Greater(sessionManager.PendingConnectionSecondsRemaining, 0f,
                 "A pending LAN client connection should expose remaining timeout time for the UI.");
-            NetworkSessionManager.Instance.CancelSessionOperation();
+            sessionManager.CancelSessionOperation();
 
             for (var frame = 0; frame < 10; frame++)
             {
@@ -244,7 +254,7 @@ namespace FriendSlop.Tests.PlayMode
             }
 
             Assert.IsFalse(NetworkManager.Singleton.IsListening, "Cancel should stop the pending LAN client.");
-            Assert.AreEqual("Connection cancelled.", NetworkSessionManager.Instance.Status);
+            Assert.AreEqual("Connection cancelled.", sessionManager.Status);
             Assert.AreEqual(CursorLockMode.None, Cursor.lockState, "Cancel should leave the UI cursor unlocked.");
             Assert.IsTrue(Cursor.visible, "Cancel should leave the UI cursor visible.");
         }

--- a/Space Game/CLAUDE.md
+++ b/Space Game/CLAUDE.md
@@ -172,6 +172,7 @@ When you finish a change:
 Read these before making non-trivial changes:
 
 - [docs/architecture.md](../docs/architecture.md) — architectural decisions and rationale. The "why" behind every rule above.
+- [docs/FeatureIntegrationContracts.md](../docs/FeatureIntegrationContracts.md) — extension points and PR contracts for agents adding features.
 - [docs/SpaceshipSceneManagement.md](../docs/SpaceshipSceneManagement.md) — current scene state, target additive multi-scene layout, scene-ownership rules.
 - [docs/RemainingFeatures.md](../docs/RemainingFeatures.md) — feature backlog. Check before claiming a feature is "missing"; it may already be tracked.
 - [docs/builder-audit.md](../docs/builder-audit.md) — GUID-determinism analysis of the editor builders. Read this before editing anything in `Assets/Scripts/Editor/`.

--- a/Space Game/CLAUDE.md
+++ b/Space Game/CLAUDE.md
@@ -85,7 +85,7 @@ If you need a reference that crosses an arrow the wrong direction, the design is
 ### 6. Size and complexity ceilings
 
 - **Files over ~400 lines must be split before adding to them.** No "I'll just append one more method." If the file is already over the limit, the next change is a refactor that brings it back under.
-- **No new singletons.** We already have five (`RoundManager.Instance`, `FriendSlopUI.Instance`, `NetworkSessionManager.Instance`, `NetworkSceneTransitionService.Instance`, `NetworkFirstPersonController.LocalPlayer`). The next time singleton-shaped state is tempting, inject the dependency via `SerializeField` or pass it at spawn time.
+- **No new singletons.** The only approved project-owned globals are `RoundManager.Instance` and `NetworkFirstPersonController.LocalPlayer`, both transitional. Inject dependencies via `SerializeField`, pass them at spawn time, or use a narrow provider/event. See `docs/SingletonAudit.md`.
 - **No `FindObjectsByType` in per-frame `Update`/`FixedUpdate`.** Cache or use a static registry.
 
 ### 7. Tests are the safety net
@@ -173,6 +173,7 @@ Read these before making non-trivial changes:
 
 - [docs/architecture.md](../docs/architecture.md) — architectural decisions and rationale. The "why" behind every rule above.
 - [docs/FeatureIntegrationContracts.md](../docs/FeatureIntegrationContracts.md) — extension points and PR contracts for agents adding features.
+- [docs/SingletonAudit.md](../docs/SingletonAudit.md) — current singleton audit and migration plan.
 - [docs/SpaceshipSceneManagement.md](../docs/SpaceshipSceneManagement.md) — current scene state, target additive multi-scene layout, scene-ownership rules.
 - [docs/RemainingFeatures.md](../docs/RemainingFeatures.md) — feature backlog. Check before claiming a feature is "missing"; it may already be tracked.
 - [docs/builder-audit.md](../docs/builder-audit.md) — GUID-determinism analysis of the editor builders. Read this before editing anything in `Assets/Scripts/Editor/`.

--- a/docs/FeatureIntegrationContracts.md
+++ b/docs/FeatureIntegrationContracts.md
@@ -15,7 +15,7 @@ Every feature PR should answer these questions in its summary:
 - What EditMode or PlayMode test proves the integration?
 - Does any visual/layout work still need human playtest?
 
-CI enforces basic architecture drift through `ArchitectureGuardrailTests`: no new singleton-style globals, no direct scene searches in frame methods, no growing already-oversized runtime files, and no wrong-way runtime/UI/editor asmdef references.
+CI enforces basic architecture drift through `ArchitectureGuardrailTests`: no new singleton-style globals, no direct scene searches in frame methods, no growing already-oversized runtime files, and no wrong-way runtime/UI/editor asmdef references. The only approved project-owned globals are documented in [SingletonAudit.md](SingletonAudit.md).
 
 ## New Planet
 

--- a/docs/FeatureIntegrationContracts.md
+++ b/docs/FeatureIntegrationContracts.md
@@ -1,0 +1,158 @@
+# Feature Integration Contracts
+
+This is the handoff for humans and AI agents adding new features to Friend Slop Retrieval. The goal is not to slow feature work down; it is to make features land through stable extension points instead of growing one-off branches in managers, UI, or builders.
+
+Before starting a feature, identify which contract below applies. If none fits, add or propose a new contract before implementing the feature.
+
+## Required Shape
+
+Every feature PR should answer these questions in its summary:
+
+- What feature contract did it use?
+- What runtime files did it touch?
+- What ScriptableObject assets or prefabs did it add?
+- What server authority path validates the player action?
+- What EditMode or PlayMode test proves the integration?
+- Does any visual/layout work still need human playtest?
+
+CI enforces basic architecture drift through `ArchitectureGuardrailTests`: no new singleton-style globals, no direct scene searches in frame methods, no growing already-oversized runtime files, and no wrong-way runtime/UI/editor asmdef references.
+
+## New Planet
+
+Use this for any playable planet, biome, or mission location.
+
+Expected path:
+
+- Add or update a `PlanetDefinition` asset.
+- Register it in `PlanetCatalog`.
+- If it has unique geometry, give it a `GameSceneDefinition` and a dedicated `Planet_*` scene.
+- The scene must contain a `PlanetEnvironment`, launchpad, player spawns, `SphereWorld`, and ship teleporter.
+- Let `PlanetSceneValidator` catch missing Build Settings entries and missing scene wiring.
+
+Do not:
+
+- Add planet-specific branches to `RoundManager`.
+- Hand-edit scene YAML for gameplay wiring.
+- Remove same-tier scene fallback until every planet in that tier owns a dedicated scene.
+
+Tests:
+
+- EditMode validation for catalog/scene wiring.
+- PlayMode smoke coverage when adding or changing scene-transition behavior.
+
+## New Objective
+
+Use this for quota variants, survival modes, collection goals, boss goals, or future win conditions.
+
+Expected path:
+
+- Create a `RoundObjective` subclass.
+- Implement `ServerInitialize`, `Evaluate`, `BuildHudStatus`, `BuildSuccessText`, and `BuildFailureText`.
+- Create a ScriptableObject asset for the objective.
+- Assign the objective through `PlanetDefinition.Objective` or the `RoundManager` default.
+
+Do not:
+
+- Add objective-specific checks directly to `RoundManager.Update`.
+- Hardcode objective result copy in `FriendSlopUI`.
+
+Tests:
+
+- EditMode tests for `Evaluate`.
+- EditMode tests for HUD/result copy when it is player-facing.
+
+## New Loot Or Item
+
+Use this for salvage, ship parts, inventory items, and future economy content.
+
+Expected path:
+
+- Add or update a prefab under the loot prefab conventions.
+- Keep networked item state on `NetworkLootItem`.
+- Spawn only on the server and use `NetworkObject.Spawn`.
+- Prefer data assets/catalogs for value, rarity, budget, and spawn rules.
+
+Do not:
+
+- Instantiate or destroy networked loot directly on clients.
+- Encode loot tables as branches in scene builders.
+- Trust client-provided throw/drop vectors without server-side clamping.
+
+Tests:
+
+- EditMode tests for pure selection/budget logic.
+- PlayMode or integration coverage for new networked spawn/deposit behavior.
+
+## New UI Screen Or Panel
+
+Use this for settings, station panels, mission briefings, score summaries, and future menus.
+
+Expected path:
+
+- Create a standalone UI component for the new screen.
+- Let `FriendSlopUI` open/close or route to it only through a small public method or serialized reference.
+- Keep screen-specific state and layout out of the main `FriendSlopUI` partials.
+- Use `PlayerPrefs` only for local user preferences, not gameplay state.
+
+Do not:
+
+- Add another large procedural section to `FriendSlopUI`.
+- Make gameplay systems depend on UI types.
+- Add a UI singleton.
+
+Tests:
+
+- EditMode tests for formatting, settings persistence helpers, or pure UI state helpers.
+- Human playtest for visual layout.
+
+## New Networked Interaction
+
+Use this for player actions that affect world state: stations, revives, damage, pickups, deposits, travel, purchases, or utility use.
+
+Expected path:
+
+- Client sends a server RPC request.
+- Server validates sender identity from `RpcParams`.
+- Server clamps untrusted vectors/amounts/indices before applying them.
+- Server updates `NetworkVariable`s or sends a one-shot client RPC.
+
+Do not:
+
+- Let clients directly mutate gameplay state.
+- Infer authority from local ownership without checking the sender.
+- Use static global state when an event, serialized reference, or existing manager can own the coordination.
+
+Tests:
+
+- EditMode tests for validation helpers.
+- PlayMode tests for multi-client authority-sensitive behavior when feasible.
+
+## New Ship Station
+
+Use this for pilot controls, holographic board flows, customization bench, storage, or utilities.
+
+Expected path:
+
+- Keep `ShipStation` as the occupancy/claim layer.
+- Add a separate station-flow component for station-specific behavior.
+- Use an interface or event to decouple the station from UI screens.
+- Put station UI in its own panel/component.
+
+Do not:
+
+- Put all station behavior into `ShipStation`.
+- Add station-specific code to `RoundManager`.
+
+Tests:
+
+- EditMode tests for claim/release or station-flow state.
+- PlayMode tests for networked station behavior.
+
+## PR Checklist For Feature Agents
+
+- No new `Instance` or `LocalPlayer` static global unless the owner explicitly approved an architecture change.
+- No `FindObjectsByType`, `FindFirstObjectByType`, or `FindObjectOfType` inside `Update`, `FixedUpdate`, or `LateUpdate`.
+- No runtime file grows past 400 lines; existing oversized files must not grow.
+- No runtime assembly reference to UI or Editor.
+- New gameplay logic has a test.
+- Visual or layout changes are marked code complete and queued for human playtest.

--- a/docs/SingletonAudit.md
+++ b/docs/SingletonAudit.md
@@ -1,0 +1,51 @@
+# Singleton Audit
+
+This audit covers project-owned singleton-style globals as of this branch. It does not include Unity/NGO service singletons such as `NetworkManager.Singleton` or Unity Services SDK accessors.
+
+## Summary
+
+| Global | Decision | Reason |
+|---|---|---|
+| `FriendSlopUI.Instance` | Removed | UI was only using itself as a lookup shortcut. Gameplay input blocking now goes through `GameplayInputState`, and UI session calls use a cached `NetworkSessionManager` reference. |
+| `NetworkSessionManager.Instance` | Removed | The manager is a scene-owned component on the `NetworkManager` object. UI and tests can hold or discover that component directly without making it global state. |
+| `NetworkSceneTransitionService.Instance` | Removed | The transition service is scene-owned infrastructure. `PrototypeNetworkBootstrapper` now passes it into the spawned `RoundManager`, which passes it to `PlanetSceneOrchestrator`. |
+| `RoundManager.Instance` | Keep for now, migrate down | There is one authoritative networked round state owner per session, but the static is overused as a service locator across gameplay/UI. Removing it needs a staged migration by feature area. |
+| `NetworkFirstPersonController.LocalPlayer` | Keep for now | This is a local-client player registry, not a game-wide manager. It is still global coupling, but it is defensible until player/UI presentation code is split further. |
+
+## Current Rule
+
+Do not add new project-owned `Instance` or `LocalPlayer` globals. `ArchitectureGuardrailTests.NoNewSingletonStyleGlobals` only allows:
+
+- `RoundManager.Instance`
+- `NetworkFirstPersonController.LocalPlayer`
+
+Any change that adds another static object access point needs an explicit architecture review and a documented reason.
+
+## Why These Three Were Removed
+
+`FriendSlopUI.Instance`, `NetworkSessionManager.Instance`, and `NetworkSceneTransitionService.Instance` were not owning unique game state. They were convenience paths from one object to another:
+
+- UI to session manager for host/join/cancel buttons and status text.
+- Tests to scene components.
+- Round scene orchestration to the scene-transition service.
+
+Those are better represented as direct references, spawn-time configuration, or a small core service like `GameplayInputState`.
+
+## Remaining Migration Plan
+
+`RoundManager.Instance` should not be removed in one large sweep. It currently coordinates phase, objective state, loot deposit, launchpad boarding, player spawning, planet choice, and UI status. The safer path is to carve off read-only or narrow command surfaces:
+
+- Phase readers should depend on a small phase source or subscribe to a round lifecycle event instead of taking the full manager.
+- Zone components (`DepositZone`, `LaunchpadZone`, `TeleporterPad`, `ShipStation`) should move toward serialized references, spawn-time setup, or a round-context registration path.
+- UI should eventually cache the active round from lifecycle events and stop polling `RoundManager.Instance` directly.
+- New objectives must stay behind `RoundObjective` assets instead of adding more logic to `RoundManager`.
+
+`NetworkFirstPersonController.LocalPlayer` can remain until the player/UI split creates a local-player provider. When that happens, prefer an evented provider (`LocalPlayerChanged`) over direct static polling.
+
+## Best-Practice Guidance For Feature Agents
+
+- Prefer `[SerializeField]` references for same-scene dependencies.
+- Prefer spawn-time configuration for runtime-spawned objects.
+- Prefer events or small context/provider components when many systems need the same state.
+- Do not use a singleton to avoid wiring a reference.
+- If a dependency is optional, resolve it once and cache it; do not search every frame.

--- a/docs/SpaceshipSceneManagement.md
+++ b/docs/SpaceshipSceneManagement.md
@@ -11,6 +11,13 @@
 - `PlanetDefinition` scene assignment status: populated for `Tier1_StarterJunk.asset` and `Tier2_RustyMoon.asset`; null for `Tier2_DeepHaul.asset` (`Cobalt Trench`), `Tier2_QuickStrike.asset` (`Volt Foundry`), `Tier2_GhostShift.asset` (`Wraith Halo`), and `Tier3_VioletGiant.asset`.
 - Immediate migration implication: Tier 1 is already largely split and should be verified/kept as the baseline. Remaining scene-split work is to finish anchors/content for `Planet_RustyMoon`, decide whether Tier 2 variants share that scene or become unique scenes, and extract the nested Tier 3 `Violet Giant` out of `FriendSlopPrototype`.
 
+## Tier 2 Scene Decision (2026-05-02)
+
+- `Tier2_DeepHaul.asset` (`Cobalt Trench`), `Tier2_QuickStrike.asset` (`Volt Foundry`), and `Tier2_GhostShift.asset` (`Wraith Halo`) are treated as mission variants on the shared `Planet_RustyMoon.unity` scene.
+- Each variant must keep an explicit `RoundObjective` assigned because its gameplay identity comes from objective/timer/quota data, not unique scene content.
+- `Tier2_RustyMoon.asset` remains the Tier 2 scene owner with `planetScene` assigned to `Planet_RustyMoon_Scene.asset`.
+- If a future playtest needs unique Tier 2 visuals, convert one variant at a time by adding a new `Planet_*` scene and assigning that variant's `planetScene`. Until then, do not create placeholder duplicate Tier 2 scenes.
+
 ## Current Vertical Slice
 
 - The prototype still boots through `Assets/Scenes/FriendSlopPrototype.unity`, but Tier 1 and one Tier 2 planet now have dedicated additive scene assets.

--- a/docs/SpaceshipSceneManagement.md
+++ b/docs/SpaceshipSceneManagement.md
@@ -1,12 +1,24 @@
 # Spaceship and Scene Management
 
+## Current Audit (2026-05-02)
+
+- Build Settings currently enable three scenes: `Assets/Scenes/FriendSlopPrototype.unity`, `Assets/Scenes/Planet_StarterJunk.unity`, and `Assets/Scenes/Planet_RustyMoon.unity`.
+- `Assets/SceneDefinitions/MainGameSceneCatalog.asset` registers only the two dedicated planet scenes: `Planet_StarterJunk_Scene.asset` and `Planet_RustyMoon_Scene.asset`.
+- `Planet_StarterJunk.unity` contains a `PlanetEnvironment` for `Tier1_StarterJunk.asset` with 4 player spawn points, 14 loot spawn points, 1 monster spawn point, a launchpad reference, a content root, and a `SphereWorld` reference. `Tier1_StarterJunk.asset` has `planetScene` assigned to `Planet_StarterJunk_Scene.asset`.
+- `Planet_RustyMoon.unity` contains a `PlanetEnvironment` for `Tier2_RustyMoon.asset` with 4 player spawn points, a launchpad reference, and a `SphereWorld` reference, but no loot or monster spawn anchors yet. `Tier2_RustyMoon.asset` has `planetScene` assigned to `Planet_RustyMoon_Scene.asset`.
+- `FriendSlopPrototype.unity` still contains nested planet content: a `PlanetEnvironment` named `Tier 3 Planet` for `Tier3_VioletGiant.asset`, with 4 player spawn points, a launchpad reference, and a `SphereWorld` reference. It has no loot or monster spawn anchors.
+- `PrototypeNetworkBootstrapper` in the bootstrap scene still carries the legacy loot-prefab list, but its player, loot, and monster spawn arrays are serialized as null scene references. Runtime spawning therefore depends on the active `PlanetEnvironment` anchors for split scenes.
+- `PlanetDefinition` scene assignment status: populated for `Tier1_StarterJunk.asset` and `Tier2_RustyMoon.asset`; null for `Tier2_DeepHaul.asset` (`Cobalt Trench`), `Tier2_QuickStrike.asset` (`Volt Foundry`), `Tier2_GhostShift.asset` (`Wraith Halo`), and `Tier3_VioletGiant.asset`.
+- Immediate migration implication: Tier 1 is already largely split and should be verified/kept as the baseline. Remaining scene-split work is to finish anchors/content for `Planet_RustyMoon`, decide whether Tier 2 variants share that scene or become unique scenes, and extract the nested Tier 3 `Violet Giant` out of `FriendSlopPrototype`.
+
 ## Current Vertical Slice
 
-- The prototype still loads `Assets/Scenes/FriendSlopPrototype.unity` as the single playable scene.
+- The prototype still boots through `Assets/Scenes/FriendSlopPrototype.unity`, but Tier 1 and one Tier 2 planet now have dedicated additive scene assets.
 - A generated dev ship interior now exists inside that scene so the lobby is walkable immediately.
 - `RoundManager` treats `Lobby`, `Success`, `Failed`, and `AllDead` as ship phases, and `Active` as the planet phase.
 - Ship stations are reusable networked interactables so pilot controls, holographic boards, module bays, customization benches, and minigames can grow as separate systems.
 - The first scene-management foundation is in code under `Assets/Scripts/SceneManagement`: scene definitions, a scene catalog, path validation, and a server-only Netcode transition service.
+- The split is incomplete: `FriendSlopPrototype.unity` still owns ship/lobby systems and one nested Tier 3 planet.
 
 ## Target Scene Layout
 
@@ -29,7 +41,7 @@
 
 ## Next Implementation Step
 
-- Create `Bootstrap`, `ShipInterior`, and the first `Planet_StarterJunk` scene assets.
-- Register them in a `GameSceneCatalog` asset.
-- Move scene-owned dev geometry out of `FriendSlopPrototype` while keeping the same spawn/station contracts.
-- Route host startup through `NetworkSceneTransitionService` once the split scenes exist and are in Build Settings.
+- Finish separating `Bootstrap` and `ShipInterior` responsibilities inside or beyond `FriendSlopPrototype`.
+- Complete per-planet anchor/content ownership for `Planet_RustyMoon`.
+- Decide whether Tier 2 catalog entries are variants of `Planet_RustyMoon` or unique scenes.
+- Move remaining nested planet content out of `FriendSlopPrototype` while keeping the same spawn/station contracts.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -135,6 +135,7 @@ The following are explicitly out of scope for this project. If you find yourself
 ## Related documents
 
 - [SpaceshipSceneManagement.md](SpaceshipSceneManagement.md) — current vertical slice, target scene layout, and scene-ownership rules.
+- [FeatureIntegrationContracts.md](FeatureIntegrationContracts.md) — feature extension points and PR contracts for AI agents.
 - [RemainingFeatures.md](RemainingFeatures.md) — feature backlog organized by system.
 - [MultiplayerQA.md](MultiplayerQA.md) — manual playtest checklist.
 - [builder-audit.md](builder-audit.md) — GUID-determinism analysis of the editor builders.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -66,7 +66,7 @@ The server triggers loads via `NetworkManager.SceneManager.LoadScene(path, LoadS
 
 **Cost.** Higher discipline required around scene ownership. Gameplay code must never `FindObjectOfType` across the additive set without filtering by scene. The `RoundManager` needs to know which planet scene is active, not "the scene."
 
-**Status.** `NetworkSceneTransitionService` skeleton exists at `Assets/Scripts/SceneManagement/`. Not yet consumed by gameplay flow. Gating criteria for marking this complete:
+**Status.** `NetworkSceneTransitionService` is consumed by the round scene orchestration path through spawn-time dependency wiring. Gating criteria for marking the full multi-scene split complete:
 
 1. `Bootstrap`, `ShipInterior`, and at least one `Planet_*` scene exist as separate assets and are in Build Settings.
 2. `GameSceneCatalog` is the only place runtime code looks up scenes (no string literals).
@@ -97,13 +97,13 @@ FriendSlop.Core         <-  FriendSlop.Networking  <-  FriendSlop.Gameplay  <-  
 
 ### D-007: File-size and singleton limits
 
-**Decision.** Files stop at ~400 lines. New singletons require explicit justification.
+**Decision.** Files stop at ~400 lines. New project-owned singleton-style globals are refused by default. The current allowed legacy globals are `RoundManager.Instance` and `NetworkFirstPersonController.LocalPlayer`; see [SingletonAudit.md](SingletonAudit.md).
 
 **Why.** Both are leading indicators that the code is growing in the wrong shape. AI agents naturally append to existing files and reach for global state. A hard cap forces the right reaction (split, inject) at the moment when the cost is still small.
 
 **Cost.** Some refactor churn. Worth it.
 
-**Status.** Two files currently exceed the cap (`FriendSlopUI.cs` ~1455, `NetworkFirstPersonController.cs` ~1321) and `FriendSlopSceneBuilder.cs` ~1297. These are flagged for split before any further additions.
+**Status.** Several runtime files still exceed the cap and are frozen by `ArchitectureGuardrailTests` baselines. `FriendSlopUI`, `NetworkFirstPersonController`, `NetworkLootItem`, `PlayerInteractor`, `RoamingMonster`, and `RoundManager` are flagged for staged splits before significant additions.
 
 ### D-008: Tests at architectural seams
 
@@ -128,7 +128,7 @@ The following are explicitly out of scope for this project. If you find yourself
 
 ## Open questions
 
-- **NGO scene-transition idiom.** The exact handoff between `RoundManager` (gameplay-phase owner) and `NetworkSceneTransitionService` (scene-load owner) needs to be settled before D-005 ships. Likely answer: `RoundManager` requests, the service executes, `RoundManager.OnNetworkSpawn` re-runs in the new scene to re-anchor.
+- **NGO scene-transition idiom.** The first handoff is settled: `PrototypeNetworkBootstrapper` passes `NetworkSceneTransitionService` into the spawned `RoundManager`, and `RoundManager` delegates additive planet loads to `PlanetSceneOrchestrator`. Late-join behavior and full ship/planet scene splitting still need tests.
 - **Late-join during transition.** What does a client see if it joins while the server is mid-load? Probably: hold them in a "Joining" UI state, let NGO sync them to the destination scene.
 - **Persistent player state across scenes.** `NetworkFirstPersonController` is currently scene-local. For multi-scene, either the player NetworkObject lives in Bootstrap (DontDestroyOnLoad-able NetworkObject), or it gets re-spawned each transition with serialized state passed through `RoundManager`. Pending decision.
 
@@ -136,6 +136,7 @@ The following are explicitly out of scope for this project. If you find yourself
 
 - [SpaceshipSceneManagement.md](SpaceshipSceneManagement.md) — current vertical slice, target scene layout, and scene-ownership rules.
 - [FeatureIntegrationContracts.md](FeatureIntegrationContracts.md) — feature extension points and PR contracts for AI agents.
+- [SingletonAudit.md](SingletonAudit.md) — singleton audit, removals, and migration plan for remaining globals.
 - [RemainingFeatures.md](RemainingFeatures.md) — feature backlog organized by system.
 - [MultiplayerQA.md](MultiplayerQA.md) — manual playtest checklist.
 - [builder-audit.md](builder-audit.md) — GUID-determinism analysis of the editor builders.


### PR DESCRIPTION
## Summary
- Apply the zip handoff bug fixes for death camera cleanup, Relay/session crash safety, and server-side carry surface validation.
- Update CI so EditMode and PlayMode test jobs run in parallel and share a composite Unity license check action.
- Complete the smaller architecture follow-ups: cache NetworkLootItem carrier lookups, reduce spectator camera allocations, and lock NetworkVariable declaration order with tests.

## Validation
- dotnet build 'Space Game\FriendSlop.Runtime.csproj' /p:GenerateMSBuildEditorConfigFile=false
- dotnet build 'Space Game\FriendSlop.EditModeTests.csproj' /p:GenerateMSBuildEditorConfigFile=false
- dotnet build 'Space Game\FriendSlop.PlayModeTests.csproj' /p:GenerateMSBuildEditorConfigFile=false
- .\tools\Run-UnityTests.ps1 -TestPlatform All (68 EditMode, 1 PlayMode)

## Playtest Notes
- Restart a round after the local player dies and confirm no orphan camera renders.
- Carry loot and dead bodies near planet surfaces, edges, and ship flat-gravity volume.
- Pick up/drop/deposit loot repeatedly and confirm no inventory or visibility regressions.
- Check GitHub Actions to confirm EditMode and PlayMode jobs start after Unity-version validation.