### PR TITLE
[Architecture/Docs] Inline cleanups, monster split, gameplay decisions doc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,13 @@
 #
 .utmp/
 **/.utmp/
+
+# Stray git LFS hooks installed under a literal "dev/null" path on Windows
+# (happens when something attempts core.hooksPath=/dev/null in a Windows shell).
+/dev/
+
+# Claude Code session metadata
+.claude/
 /[Ll]ibrary/
 /[Tt]emp/
 /[Oo]bj/

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -192,3 +192,50 @@ Grooming questions:
 - Should validation run from a menu item, CI, or both?
 - Which warnings should block a merge?
 - Should each planet asset declare its expected minimum content?
+
+## 15. Architecture follow-ups
+
+Tracked engineering work surfaced in the 2026-05-03 audit. Each is its own focused PR — they intentionally were not bundled into [#18](https://github.com/TheSchlote/Friend-Slop/pull/18) so that scope and review stay tight.
+
+### 15a. Pre-emptive splits of files at exact baseline
+
+These runtime files sit at the `ArchitectureGuardrailTests` baseline ceiling, meaning the next added line fails CI. Each split is mechanical (carve into partials by responsibility) and unblocks future feature work in those areas.
+
+- `Assets/Scripts/Loot/NetworkLootItem.cs` (703/703) — split candidates: pickup/drop network flow, deposit/surface logic, slot/inventory state.
+- `Assets/Scripts/Player/PlayerInteractor.cs` (529/529) — split candidates: focus/raycast, pickup/drop input, weapon use.
+- `Assets/Scripts/UI/FriendSlopUI.BuildUi.cs` (517/517) — split per built section (HUD/menu/chat/etc).
+- `Assets/Scripts/Player/NetworkFirstPersonController.cs` (728/739) — only 11 lines from baseline; movement/look/crouch logic is the next obvious extraction.
+
+After each split: drop the file's entry from `ExistingOversizedRuntimeFiles` in `ArchitectureGuardrailTests.cs` if the main file lands under 400.
+
+### 15b. Further `RoundManager` carving
+
+Currently 800/1000 baseline after codex's PlanetSceneOrchestrator + `.PlanetEnvironment` + `.PlanetTravelCleanup` partials. Natural next splits:
+
+- `RoundManager.PlayerPlacement.cs` — `RespawnPlayersAtPlanet`, `ServerMovePlayersToShip`, `ServerTeleportPlayer*` family.
+- `RoundManager.Boarding.cs` — launchpad submit + boarding tracking.
+
+Goal: bring main `RoundManager.cs` under 400 so its baseline can be removed.
+
+### 15c. Asmdef split — D-006
+
+Per [docs/architecture.md](docs/architecture.md) decision D-006: split `FriendSlop.Runtime` into `Core ← Networking ← Gameplay ← UI`. The architecture doc explicitly calls this a "single focused PR." Cheapest first step: carve `FriendSlop.Core` out (pure data: `SphereWorld`, `RoundStateUtility`, `JoinCodeUtility`, `CarrySyncUtility`, `RoundPhase`, `ShipPartType`) so tests can reference Core without pulling Netcode.
+
+### 15d. `RoundManager.Instance` migration
+
+Per [docs/SingletonAudit.md](docs/SingletonAudit.md): "should not be removed in one large sweep." Per-feature carve-off when each zone is touched:
+
+- `LaunchpadZone`, `DepositZone`, `TeleporterPad`, `ShipStation` → spawn-time wiring of a small round-context provider.
+- UI subscribes to round lifecycle events and stops polling `RoundManager.Instance` directly.
+
+Track removal progress by counting `RoundManager.Instance` references in the codebase; goal is 0 in non-test runtime code.
+
+### 15e. `FriendSlopUI` polling rewrite
+
+`RefreshUi()` runs a full layout diff every Update. Pair with the prefab move tracked in section 11: drive each widget from `NetworkVariable.OnValueChanged` instead of polling, so the health bar only updates when health changes (not 60×/sec).
+
+### 15f. Test-coverage backfill
+
+Currently no EditMode coverage for: `NetworkSessionManager` (mock-needed), `FriendSlopUI` partials, `PlayerInteractor`, `NetworkFirstPersonController` health/lifecycle/movement, weapons (`LaserGun`, `BoxingGloves`). The seams that already break are well-covered; gameplay surface that *could* break invisibly is not.
+
+Lowest-hanging fruit: `LaserGun` / `BoxingGloves` — they're small, server-authoritative, and have clear pass/fail predicates.

--- a/Space Game/Assets/Scripts/Core/DayNightCycle.cs
+++ b/Space Game/Assets/Scripts/Core/DayNightCycle.cs
@@ -40,6 +40,8 @@ namespace FriendSlop.Core
 
         public override void OnNetworkSpawn()
         {
+            DayNightCycleRegistry.Register(this);
+
             var lightObj = GameObject.Find("Tiny Planet Sun");
             if (lightObj != null) _dirLight = lightObj.GetComponent<Light>();
 
@@ -67,6 +69,8 @@ namespace FriendSlop.Core
 
         public override void OnNetworkDespawn()
         {
+            DayNightCycleRegistry.Unregister(this);
+
             // Restore the original skybox material.
             if (_originalSkybox != null)
                 RenderSettings.skybox = _originalSkybox;

--- a/Space Game/Assets/Scripts/Core/DayNightCycleRegistry.cs
+++ b/Space Game/Assets/Scripts/Core/DayNightCycleRegistry.cs
@@ -1,0 +1,31 @@
+using System;
+
+namespace FriendSlop.Core
+{
+    public static class DayNightCycleRegistry
+    {
+        public static event Action<DayNightCycle, DayNightCycle> CurrentChanged;
+
+        public static DayNightCycle Current { get; private set; }
+
+        internal static void Register(DayNightCycle cycle)
+        {
+            if (cycle == null || Current == cycle)
+                return;
+
+            var previous = Current;
+            Current = cycle;
+            CurrentChanged?.Invoke(previous, Current);
+        }
+
+        internal static void Unregister(DayNightCycle cycle)
+        {
+            if (cycle == null || Current != cycle)
+                return;
+
+            var previous = Current;
+            Current = null;
+            CurrentChanged?.Invoke(previous, null);
+        }
+    }
+}

--- a/Space Game/Assets/Scripts/Core/DayNightCycleRegistry.cs.meta
+++ b/Space Game/Assets/Scripts/Core/DayNightCycleRegistry.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: db8ade992c2142d4a15652e3624e3002
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Space Game/Assets/Scripts/Hazards/RoamingMonster.Movement.cs
+++ b/Space Game/Assets/Scripts/Hazards/RoamingMonster.Movement.cs
@@ -1,0 +1,110 @@
+using FriendSlop.Core;
+using FriendSlop.Player;
+using UnityEngine;
+
+namespace FriendSlop.Hazards
+{
+    public partial class RoamingMonster
+    {
+        private void MoveToward(SphereWorld world, Vector3 targetPosition)
+        {
+            var up = world.GetUp(transform.position);
+            var tangent = Vector3.ProjectOnPlane(targetPosition - transform.position, up);
+            if (tangent.sqrMagnitude < 0.001f)
+            {
+                return;
+            }
+
+            tangent.Normalize();
+            var candidatePosition = transform.position + tangent * moveSpeed * Time.deltaTime;
+            transform.position = world.GetSurfacePoint(world.GetUp(candidatePosition), surfaceHeight);
+            AlignToSurface(world, tangent, Time.deltaTime);
+        }
+
+        // Returns true when the attack landed, triggering a retreat.
+        private bool TryAttack(SphereWorld world, NetworkFirstPersonController player)
+        {
+            if (player.IsDead) return false;
+            if (Time.time < nextAttackTime || Vector3.Distance(transform.position, player.transform.position) > attackDistance)
+                return false;
+
+            nextAttackTime = Time.time + attackCooldown;
+
+            var away = Vector3.ProjectOnPlane(player.transform.position - transform.position, world.GetUp(player.transform.position));
+            if (away.sqrMagnitude < 0.001f)
+                away = player.transform.forward;
+
+            away.Normalize();
+            var impulse = away * knockbackStrength + world.GetUp(player.transform.position) * 3f;
+
+            player.ServerForceDropHeld(impulse);
+            player.StunClientRpc(stunDuration, impulse);
+            player.ServerTakeDamage(attackDamage);
+
+            _stunnedPlayer = player;
+            _stunnedPlayerUntil = Time.time + stunDuration;
+
+            return true;
+        }
+
+        private void PickRoamTarget(SphereWorld world)
+        {
+            if (world == null)
+            {
+                roamTarget = spawnPosition;
+                return;
+            }
+
+            // Pick the offset in the local tangent plane so a near-radial random pick
+            // doesn't collapse back onto spawnPosition after surface projection.
+            var up = world.GetUp(spawnPosition);
+            var tangent = Vector3.ProjectOnPlane(Random.onUnitSphere, up);
+            if (tangent.sqrMagnitude < 0.01f)
+                tangent = Vector3.ProjectOnPlane(Vector3.right, up);
+            if (tangent.sqrMagnitude < 0.01f)
+                tangent = Vector3.ProjectOnPlane(Vector3.forward, up);
+            tangent.Normalize();
+
+            var distance = Random.Range(roamRadius * 0.5f, roamRadius);
+            var offsetPoint = spawnPosition + tangent * distance;
+            roamTarget = world.GetSurfacePoint(world.GetUp(offsetPoint), surfaceHeight);
+        }
+
+        private void PickRetreatTarget(SphereWorld world, Vector3 fromPosition)
+        {
+            var up = world.GetUp(transform.position);
+            var awayDir = Vector3.ProjectOnPlane(transform.position - fromPosition, up);
+            if (awayDir.sqrMagnitude < 0.001f)
+                awayDir = transform.forward;
+            awayDir.Normalize();
+            var offsetPoint = transform.position + awayDir * roamRadius;
+            roamTarget = world.GetSurfacePoint(world.GetUp(offsetPoint), surfaceHeight);
+        }
+
+        private void PickInvestigateTarget(SphereWorld world)
+        {
+            if (world == null)
+            {
+                _investigateTarget = _lastKnownPosition;
+                return;
+            }
+
+            var offsetPoint = _lastKnownPosition + Random.onUnitSphere * investigateWanderRadius;
+            _investigateTarget = world.GetSurfacePoint(world.GetUp(offsetPoint), surfaceHeight);
+        }
+
+        private void AlignToSurface(SphereWorld world, Vector3 forwardHint, float deltaTime)
+        {
+            if (world == null)
+            {
+                return;
+            }
+
+            var up = world.GetUp(transform.position);
+            var targetRotation = world.GetSurfaceRotation(up, forwardHint);
+            transform.rotation = deltaTime >= 1f
+                ? targetRotation
+                : Quaternion.Slerp(transform.rotation, targetRotation, rotationSharpness * deltaTime);
+        }
+    }
+}

--- a/Space Game/Assets/Scripts/Hazards/RoamingMonster.Movement.cs.meta
+++ b/Space Game/Assets/Scripts/Hazards/RoamingMonster.Movement.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9f2cfb8af7194b15808cc2a0f8189b27
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Space Game/Assets/Scripts/Hazards/RoamingMonster.Perception.cs
+++ b/Space Game/Assets/Scripts/Hazards/RoamingMonster.Perception.cs
@@ -1,0 +1,149 @@
+using FriendSlop.Core;
+using FriendSlop.Player;
+using UnityEngine;
+
+namespace FriendSlop.Hazards
+{
+    public partial class RoamingMonster
+    {
+        private NetworkFirstPersonController FindNearestPlayer(SphereWorld world)
+        {
+            NetworkFirstPersonController bestPlayer = null;
+            var bestDistance = detectionRange;
+
+            var up = _frameUp;
+            var surfaceForward = _frameSurfaceForward;
+
+            foreach (var player in NetworkFirstPersonController.ActivePlayers)
+            {
+                if (player == null || !player.IsSpawned)
+                    continue;
+
+                if (player.IsDead)
+                    continue;
+
+                if (player == _stunnedPlayer && Time.time < _stunnedPlayerUntil)
+                    continue;
+
+                var distance = Vector3.Distance(transform.position, player.transform.position);
+                if (distance >= bestDistance)
+                    continue;
+
+                // Stealth model: more body parts blocked → harder to spot. Crouching shrinks
+                // the sampled body height, so cover hides more of the player.
+                var visibility = ComputeBodyVisibility(world, player, distance);
+                if (visibility <= 0f)
+                    continue;
+
+                if (distance < proximityDetectionRange)
+                {
+                    // Point-blank: still detected as long as something is exposed.
+                    bestDistance = distance;
+                    bestPlayer = player;
+                    continue;
+                }
+
+                var effectiveRange = detectionRange * visibility;
+                if (distance >= effectiveRange)
+                    continue;
+
+                var toPlayer = Vector3.ProjectOnPlane(player.transform.position - transform.position, up);
+                if (toPlayer.sqrMagnitude < 0.001f)
+                    continue;
+
+                if (Vector3.Angle(surfaceForward, toPlayer) > visionAngle * 0.5f)
+                    continue;
+
+                bestDistance = distance;
+                bestPlayer = player;
+            }
+
+            return bestPlayer;
+        }
+
+        private float ComputeBodyVisibility(SphereWorld world, NetworkFirstPersonController player, float distance)
+        {
+            if (player == null || world == null) return 0f;
+
+            var origin = transform.position + _frameUp * visionOriginHeight;
+            var up = world.GetUp(player.transform.position);
+            var bodyHeight = Mathf.Max(0.1f, player.CurrentBodyHeight);
+
+            // Linecasts are the per-frame cost in this method. At distance, sub-meter precision
+            // doesn't help — sample the torso only. At medium range, two points (waist + chest).
+            // At close range, full sweep — that's where stealth matters most.
+            var sampleCount = distance < proximityDetectionRange * 2f
+                ? BodySampleHeights.Length
+                : distance < detectionRange * 0.5f
+                    ? 2
+                    : 1;
+
+            var visible = 0;
+            for (var i = 0; i < sampleCount; i++)
+            {
+                // When sampling fewer points, prefer middle samples so we don't bias toward
+                // feet/head — those are the points cover most often hides.
+                var heightIndex = sampleCount switch
+                {
+                    1 => 1,
+                    2 => i == 0 ? 1 : 2,
+                    _ => i,
+                };
+                var point = player.transform.position + up * (bodyHeight * BodySampleHeights[heightIndex]);
+                if (!Physics.Linecast(origin, point, out var hit))
+                {
+                    visible++;
+                    continue;
+                }
+
+                if (hit.collider != null && hit.collider.transform.root == player.transform.root)
+                    visible++;
+            }
+
+            return (float)visible / sampleCount;
+        }
+
+        private bool CanDetectPlayer(SphereWorld world, NetworkFirstPersonController player)
+        {
+            if (player == null || !player.IsSpawned)
+                return false;
+
+            if (player.IsDead)
+                return false;
+
+            if (player == _stunnedPlayer && Time.time < _stunnedPlayerUntil)
+                return false;
+
+            var distance = Vector3.Distance(transform.position, player.transform.position);
+
+            if (distance < proximityDetectionRange)
+                return true;
+
+            if (distance >= detectionRange)
+                return false;
+
+            var up = _frameUp;
+            var surfaceForward = _frameSurfaceForward;
+
+            var toPlayer = Vector3.ProjectOnPlane(player.transform.position - transform.position, up);
+            if (toPlayer.sqrMagnitude < 0.001f)
+                return false;
+
+            if (Vector3.Angle(surfaceForward, toPlayer) > visionAngle * 0.5f)
+                return false;
+
+            return !IsOccluded(world, player);
+        }
+
+        private bool IsOccluded(SphereWorld world, NetworkFirstPersonController player)
+        {
+            var origin      = transform.position        + _frameUp                                           * visionOriginHeight;
+            var destination = player.transform.position + world.GetUp(player.transform.position) * visionOriginHeight;
+
+            if (!Physics.Linecast(origin, destination, out var hit))
+                return false;
+
+            return hit.collider.transform.root != player.transform.root;
+        }
+    }
+}

--- a/Space Game/Assets/Scripts/Hazards/RoamingMonster.Perception.cs.meta
+++ b/Space Game/Assets/Scripts/Hazards/RoamingMonster.Perception.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e9ebb91621ce405f8e1c107cc01736bc
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Space Game/Assets/Scripts/Hazards/RoamingMonster.cs
+++ b/Space Game/Assets/Scripts/Hazards/RoamingMonster.cs
@@ -7,7 +7,7 @@ using UnityEngine;
 namespace FriendSlop.Hazards
 {
     [RequireComponent(typeof(NetworkObject))]
-    public class RoamingMonster : NetworkBehaviour
+    public partial class RoamingMonster : NetworkBehaviour
     {
         [SerializeField] private float detectionRange = 30f;
         [SerializeField] private float attackDistance = 2f;
@@ -32,13 +32,16 @@ namespace FriendSlop.Hazards
         [SerializeField] private int attackDamage = 20;
         [SerializeField] private int maxHealth = 100;
 
+        // Declaration order matters for NGO: deserializes in declaration order.
+        // Keep _health before _isDead so any future reader of _isDead.OnValueChanged can
+        // also read the matching health value if it ever needs to.
         private NetworkVariable<int> _health = new(100);
+        private NetworkVariable<bool> _isDead = new(false);
 
         private enum State { Roaming, Chasing, Investigating }
 
         private static readonly float[] BodySampleHeights = { 0.25f, 0.5f, 0.75f, 0.95f };
 
-        private bool _isDead;
         private Renderer[] _renderers;
         private CapsuleCollider _capsuleCollider;
 
@@ -63,8 +66,20 @@ namespace FriendSlop.Hazards
 
         public override void OnNetworkSpawn()
         {
-            if (_health.Value <= 0)
+            _isDead.OnValueChanged += OnDeadChanged;
+            if (_isDead.Value)
                 ApplyDeadState();
+        }
+
+        public override void OnNetworkDespawn()
+        {
+            _isDead.OnValueChanged -= OnDeadChanged;
+        }
+
+        private void OnDeadChanged(bool previous, bool current)
+        {
+            if (current) ApplyDeadState();
+            else ApplyAliveState();
         }
 
         private void Awake()
@@ -89,7 +104,7 @@ namespace FriendSlop.Hazards
 
         private void Update()
         {
-            if (!IsServer || _isDead || !RoundManagerRegistry.IsCurrentPhase(RoundPhase.Active))
+            if (!IsServer || _isDead.Value || !RoundManagerRegistry.IsCurrentPhase(RoundPhase.Active))
             {
                 _roundActive = false;
                 return;
@@ -200,27 +215,10 @@ namespace FriendSlop.Hazards
 
         public void ServerTakeDamage(int damage)
         {
-            if (!IsServer || _isDead) return;
+            if (!IsServer || _isDead.Value) return;
             _health.Value = Mathf.Max(0, _health.Value - damage);
             if (_health.Value <= 0)
-            {
-                _isDead = true;
-                DieClientRpc();
-            }
-        }
-
-        [Rpc(SendTo.ClientsAndHost)]
-        private void DieClientRpc()
-        {
-            _isDead = true;
-            ApplyDeadState();
-        }
-
-        [Rpc(SendTo.ClientsAndHost)]
-        private void ReviveClientRpc()
-        {
-            _isDead = false;
-            ApplyAliveState();
+                _isDead.Value = true;
         }
 
         private void ApplyDeadState()
@@ -245,8 +243,7 @@ namespace FriendSlop.Hazards
             }
 
             _health.Value = maxHealth;
-            _isDead = false;
-            ReviveClientRpc();
+            _isDead.Value = false;
 
             transform.position = spawnPosition;
             nextAttackTime = 0f;
@@ -262,228 +259,5 @@ namespace FriendSlop.Hazards
             PickRoamTarget(world);
         }
 
-        private NetworkFirstPersonController FindNearestPlayer(SphereWorld world)
-        {
-            NetworkFirstPersonController bestPlayer = null;
-            var bestDistance = detectionRange;
-
-            var up = _frameUp;
-            var surfaceForward = _frameSurfaceForward;
-
-            foreach (var player in NetworkFirstPersonController.ActivePlayers)
-            {
-                if (player == null || !player.IsSpawned)
-                    continue;
-
-                if (player.IsDead)
-                    continue;
-
-                if (player == _stunnedPlayer && Time.time < _stunnedPlayerUntil)
-                    continue;
-
-                var distance = Vector3.Distance(transform.position, player.transform.position);
-                if (distance >= bestDistance)
-                    continue;
-
-                // Stealth model: more body parts blocked → harder to spot. Crouching shrinks
-                // the sampled body height, so cover hides more of the player.
-                var visibility = ComputeBodyVisibility(world, player);
-                if (visibility <= 0f)
-                    continue;
-
-                if (distance < proximityDetectionRange)
-                {
-                    // Point-blank: still detected as long as something is exposed.
-                    bestDistance = distance;
-                    bestPlayer = player;
-                    continue;
-                }
-
-                var effectiveRange = detectionRange * visibility;
-                if (distance >= effectiveRange)
-                    continue;
-
-                var toPlayer = Vector3.ProjectOnPlane(player.transform.position - transform.position, up);
-                if (toPlayer.sqrMagnitude < 0.001f)
-                    continue;
-
-                if (Vector3.Angle(surfaceForward, toPlayer) > visionAngle * 0.5f)
-                    continue;
-
-                bestDistance = distance;
-                bestPlayer = player;
-            }
-
-            return bestPlayer;
-        }
-
-        private float ComputeBodyVisibility(SphereWorld world, NetworkFirstPersonController player)
-        {
-            if (player == null || world == null) return 0f;
-
-            var origin = transform.position + _frameUp * visionOriginHeight;
-            var up = world.GetUp(player.transform.position);
-            var bodyHeight = Mathf.Max(0.1f, player.CurrentBodyHeight);
-            var visible = 0;
-
-            for (var i = 0; i < BodySampleHeights.Length; i++)
-            {
-                var point = player.transform.position + up * (bodyHeight * BodySampleHeights[i]);
-                if (!Physics.Linecast(origin, point, out var hit))
-                {
-                    visible++;
-                    continue;
-                }
-
-                if (hit.collider != null && hit.collider.transform.root == player.transform.root)
-                    visible++;
-            }
-
-            return (float)visible / BodySampleHeights.Length;
-        }
-
-        private bool CanDetectPlayer(SphereWorld world, NetworkFirstPersonController player)
-        {
-            if (player == null || !player.IsSpawned)
-                return false;
-
-            if (player.IsDead)
-                return false;
-
-            if (player == _stunnedPlayer && Time.time < _stunnedPlayerUntil)
-                return false;
-
-            var distance = Vector3.Distance(transform.position, player.transform.position);
-
-            if (distance < proximityDetectionRange)
-                return true;
-
-            if (distance >= detectionRange)
-                return false;
-
-            var up = _frameUp;
-            var surfaceForward = _frameSurfaceForward;
-
-            var toPlayer = Vector3.ProjectOnPlane(player.transform.position - transform.position, up);
-            if (toPlayer.sqrMagnitude < 0.001f)
-                return false;
-
-            if (Vector3.Angle(surfaceForward, toPlayer) > visionAngle * 0.5f)
-                return false;
-
-            return !IsOccluded(world, player);
-        }
-
-        private bool IsOccluded(SphereWorld world, NetworkFirstPersonController player)
-        {
-            var origin      = transform.position        + _frameUp                                           * visionOriginHeight;
-            var destination = player.transform.position + world.GetUp(player.transform.position) * visionOriginHeight;
-
-            if (!Physics.Linecast(origin, destination, out var hit))
-                return false;
-
-            return hit.collider.transform.root != player.transform.root;
-        }
-
-        private void MoveToward(SphereWorld world, Vector3 targetPosition)
-        {
-            var up = world.GetUp(transform.position);
-            var tangent = Vector3.ProjectOnPlane(targetPosition - transform.position, up);
-            if (tangent.sqrMagnitude < 0.001f)
-            {
-                return;
-            }
-
-            tangent.Normalize();
-            var candidatePosition = transform.position + tangent * moveSpeed * Time.deltaTime;
-            transform.position = world.GetSurfacePoint(world.GetUp(candidatePosition), surfaceHeight);
-            AlignToSurface(world, tangent, Time.deltaTime);
-        }
-
-        // Returns true when the attack landed, triggering a retreat.
-        private bool TryAttack(SphereWorld world, NetworkFirstPersonController player)
-        {
-            if (player.IsDead) return false;
-            if (Time.time < nextAttackTime || Vector3.Distance(transform.position, player.transform.position) > attackDistance)
-                return false;
-
-            nextAttackTime = Time.time + attackCooldown;
-
-            var away = Vector3.ProjectOnPlane(player.transform.position - transform.position, world.GetUp(player.transform.position));
-            if (away.sqrMagnitude < 0.001f)
-                away = player.transform.forward;
-
-            away.Normalize();
-            var impulse = away * knockbackStrength + world.GetUp(player.transform.position) * 3f;
-
-            player.ServerForceDropHeld(impulse);
-            player.StunClientRpc(stunDuration, impulse);
-            player.ServerTakeDamage(attackDamage);
-
-            _stunnedPlayer = player;
-            _stunnedPlayerUntil = Time.time + stunDuration;
-
-            return true;
-        }
-
-        private void PickRoamTarget(SphereWorld world)
-        {
-            if (world == null)
-            {
-                roamTarget = spawnPosition;
-                return;
-            }
-
-            // Pick the offset in the local tangent plane so a near-radial random pick
-            // doesn't collapse back onto spawnPosition after surface projection.
-            var up = world.GetUp(spawnPosition);
-            var tangent = Vector3.ProjectOnPlane(Random.onUnitSphere, up);
-            if (tangent.sqrMagnitude < 0.01f)
-                tangent = Vector3.ProjectOnPlane(Vector3.right, up);
-            if (tangent.sqrMagnitude < 0.01f)
-                tangent = Vector3.ProjectOnPlane(Vector3.forward, up);
-            tangent.Normalize();
-
-            var distance = Random.Range(roamRadius * 0.5f, roamRadius);
-            var offsetPoint = spawnPosition + tangent * distance;
-            roamTarget = world.GetSurfacePoint(world.GetUp(offsetPoint), surfaceHeight);
-        }
-
-        private void PickRetreatTarget(SphereWorld world, Vector3 fromPosition)
-        {
-            var up = world.GetUp(transform.position);
-            var awayDir = Vector3.ProjectOnPlane(transform.position - fromPosition, up);
-            if (awayDir.sqrMagnitude < 0.001f)
-                awayDir = transform.forward;
-            awayDir.Normalize();
-            var offsetPoint = transform.position + awayDir * roamRadius;
-            roamTarget = world.GetSurfacePoint(world.GetUp(offsetPoint), surfaceHeight);
-        }
-
-        private void PickInvestigateTarget(SphereWorld world)
-        {
-            if (world == null)
-            {
-                _investigateTarget = _lastKnownPosition;
-                return;
-            }
-
-            var offsetPoint = _lastKnownPosition + Random.onUnitSphere * investigateWanderRadius;
-            _investigateTarget = world.GetSurfacePoint(world.GetUp(offsetPoint), surfaceHeight);
-        }
-
-        private void AlignToSurface(SphereWorld world, Vector3 forwardHint, float deltaTime)
-        {
-            if (world == null)
-            {
-                return;
-            }
-
-            var up = world.GetUp(transform.position);
-            var targetRotation = world.GetSurfaceRotation(up, forwardHint);
-            transform.rotation = deltaTime >= 1f
-                ? targetRotation
-                : Quaternion.Slerp(transform.rotation, targetRotation, rotationSharpness * deltaTime);
-        }
     }
 }

--- a/Space Game/Assets/Scripts/UI/FriendSlopUI.BuildUi.cs
+++ b/Space Game/Assets/Scripts/UI/FriendSlopUI.BuildUi.cs
@@ -69,7 +69,6 @@ namespace FriendSlop.UI
             moneyOutline.effectColor = Color.black;
             moneyOutline.effectDistance = new Vector2(2f, -2f);
             timerText = CreateText("Timer", hudRoot.transform, "Parts: Cockpit missing | Wings missing | Engine missing", 20, TextAnchor.UpperLeft, new Vector2(0f, 1f), new Vector2(0f, 1f), Vector2.zero, new Vector2(760f, 32f));
-            carriedText = CreateText("Carried", hudRoot.transform, string.Empty, 19, TextAnchor.UpperLeft, new Vector2(0f, 1f), new Vector2(0f, 1f), new Vector2(0f, -38f), new Vector2(620f, 30f));
             resultText = CreateText("Result", hudRoot.transform, string.Empty, 22, TextAnchor.UpperLeft, new Vector2(0f, 1f), new Vector2(0f, 1f), new Vector2(0f, -78f), new Vector2(720f, 42f));
 
             promptText = CreateText("Prompt", canvasObject.transform, string.Empty, 24, TextAnchor.LowerCenter, new Vector2(0.5f, 0f), new Vector2(0.5f, 0f), new Vector2(0f, 72f), new Vector2(760f, 42f));

--- a/Space Game/Assets/Scripts/UI/FriendSlopUI.Hud.cs
+++ b/Space Game/Assets/Scripts/UI/FriendSlopUI.Hud.cs
@@ -19,7 +19,6 @@ namespace FriendSlop.UI
 
             SetSize(hudRect, new Vector2(hudWidth, 180f));
             SetSize(timerText.rectTransform, new Vector2(hudWidth, 32f));
-            SetSize(carriedText.rectTransform, new Vector2(Mathf.Min(hudWidth, 700f), 30f));
             SetSize(resultText.rectTransform, new Vector2(Mathf.Min(hudWidth, 820f), 42f));
             SetSize(moneyPanelRect, new Vector2(moneyWidth, 44f));
         }
@@ -196,15 +195,14 @@ namespace FriendSlop.UI
                 return;
             }
 
-            if (_dayNightCycle == null)
-                _dayNightCycle = Object.FindFirstObjectByType<DayNightCycle>();
-            if (_dayNightCycle == null)
+            var dayNight = DayNightCycleRegistry.Current;
+            if (dayNight == null)
             {
                 _sunGlareImage.color = new Color(1f, 0.95f, 0.82f, 0f);
                 return;
             }
 
-            var rawToSun  = _dayNightCycle.SunWorldPosition - cam.transform.position;
+            var rawToSun  = dayNight.SunWorldPosition - cam.transform.position;
             var distToSun = rawToSun.magnitude;
             var toSun     = rawToSun / distToSun;
             var lookDot   = Vector3.Dot(cam.transform.forward, toSun);

--- a/Space Game/Assets/Scripts/UI/FriendSlopUI.cs
+++ b/Space Game/Assets/Scripts/UI/FriendSlopUI.cs
@@ -73,7 +73,6 @@ namespace FriendSlop.UI
 
         // ── Environment effects ───────────────────────────────────────────────
         private Image _sunGlareImage;
-        private DayNightCycle _dayNightCycle;
         private Image _fadeOverlayImage;
         private float _fadeAlpha;
         private const float FadeSpeed = 2.2f;
@@ -117,7 +116,6 @@ namespace FriendSlop.UI
         private Text quotaText;
         private Text timerText;
         private Text promptText;
-        private Text carriedText;
         private Text resultText;
         private InputField joinInput;
         private InputField playerNameInput;
@@ -418,18 +416,9 @@ namespace FriendSlop.UI
             }
 
             var localPlayer = LocalPlayerRegistry.Current;
-            if (localPlayer != null)
-            {
-                promptText.text = localPlayer.Interactor != null ? localPlayer.Interactor.CurrentPrompt : string.Empty;
-                carriedText.text = localPlayer.HeldItem != null
-                    ? $"Carrying: {localPlayer.HeldItem.ItemName} (${localPlayer.HeldItem.Value})"
-                    : string.Empty;
-            }
-            else
-            {
-                promptText.text = string.Empty;
-                carriedText.text = string.Empty;
-            }
+            promptText.text = localPlayer != null && localPlayer.Interactor != null
+                ? localPlayer.Interactor.CurrentPrompt
+                : string.Empty;
 
             UpdateStaminaBar(localPlayer, gameplayPhase);
             UpdateHealthBar(localPlayer, gameplayPhase);

--- a/Space Game/Assets/Tests/EditMode/Editor/ArchitectureGuardrailTests.cs
+++ b/Space Game/Assets/Tests/EditMode/Editor/ArchitectureGuardrailTests.cs
@@ -18,9 +18,8 @@ namespace FriendSlop.Tests.EditMode
             ["Assets/Scripts/Loot/NetworkLootItem.cs"] = 703,
             ["Assets/Scripts/Networking/NetworkSessionManager.cs"] = 621,
             ["Assets/Scripts/Player/PlayerInteractor.cs"] = 529,
-            ["Assets/Scripts/UI/FriendSlopUI.BuildUi.cs"] = 518,
-            ["Assets/Scripts/UI/FriendSlopUI.cs"] = 496,
-            ["Assets/Scripts/Hazards/RoamingMonster.cs"] = 489,
+            ["Assets/Scripts/UI/FriendSlopUI.BuildUi.cs"] = 517,
+            ["Assets/Scripts/UI/FriendSlopUI.cs"] = 477,
         };
 
         private static readonly HashSet<string> AllowedSingletons = new()

--- a/docs/GameplayDecisions.md
+++ b/docs/GameplayDecisions.md
@@ -1,0 +1,287 @@
+# Gameplay Decisions
+
+Open design questions for Friend Slop Retrieval. This is a working document for you and your friend to talk through and check off as decisions land.
+
+Each section includes: the question, why it matters downstream, the concrete options on the table, and my read on the right call. None of these are technical blockers — they're design calls that will shape the next set of features.
+
+When a decision is made, replace the **Decided?** line with the choice and a short rationale, then update the relevant section of [BACKLOG.md](../BACKLOG.md) and (if it changes architecture) [docs/architecture.md](architecture.md).
+
+---
+
+## 1. Tier 2 planet identity
+
+**Question.** Are Cobalt Trench, Volt Foundry, Wraith Halo, Deep Haul, and Ghost Shift unique planets, or mission variants on the same scene?
+
+**Why it matters.** Today they all fall back to Rusty Moon's environment. That's fine as a stub but every additional planet asset compounds the visual sameness. The decision drives whether the scene-split work (BACKLOG #1) needs five new scenes per tier or just five new `PlanetDefinition` assets pointing at one shared scene with different objectives.
+
+**Options:**
+- **A. Mission variants on the same scene** — Each tier 2 planet uses the same scene (Rusty Moon) but has a distinct `PlanetDefinition.asset` with a unique `RoundObjective`, loot pool, and HUD copy. Cheap, ships fast, leans into the "you've been here before but the job is different" framing. Risk: visually monotone.
+- **B. Unique planets, unique scenes** — Each tier 2 gets its own scene with its own geometry, lighting, hazards. Aligns with the "one planet per scene" architecture target. Cost: ~5 new scenes worth of authoring + ~1 PR per planet per Phase-2 of the planet split.
+- **C. Hybrid** — Two or three "real" tier 2 planets with their own scenes (the marquee ones), the rest as mission variants on Rusty Moon framed as "return contracts."
+
+**My read.** Start with **C**. Pick two unique tier 2 planets that read as visually distinct (Cobalt Trench = water/cave, Volt Foundry = industrial). The other three become "Rusty Moon: [variant name]" contracts with clearly different objectives. This gets visual variety where it counts and keeps scene authoring manageable.
+
+**Decided?** Pending.
+
+---
+
+## 2. Progression endpoint and run loop
+
+**Question.** What happens when a crew clears the final tier? `PlanetCatalog.MaxTier` is 10; authored content only reaches 3.
+
+**Why it matters.** Right now there's no defined "win the game" state. Every UI screen, the round-end transition, replay decisions, and even saved-progress design depend on this answer.
+
+**Options:**
+- **A. Run-based (rogue-like).** Final tier success → credits → return to lobby with a session score. Each session starts from tier 1. Optional: persistent unlocks (cosmetics, ship modules) carry between runs.
+- **B. Endless cycle.** Final tier success loops back to tier 1 with a difficulty multiplier (more hazards, higher quotas). The "ending" is whenever the crew dies out. Score-attack framing.
+- **C. Authored campaign with epilogue.** Tier 10 has unique narrative content; success ends the expedition; failure → game over. Fixed-length experience.
+- **D. Open-ended sandbox.** Pick which planet to fly to from a star map; no forced tier progression; "win" by hitting a money goal you set.
+
+**My read.** **A (run-based)** fits a co-op salvage game's repeat-play loop best, and lets you ship with tier 3 content while the loop still feels complete. The "return to lobby" beat is something `RoundManager` already handles structurally. **B** is a strong follow-up once the loop is fun.
+
+**Failure handling.** If a crew All-Dead's on a mid-tier planet, do they restart that tier or lose the run? Recommendation: lose the run on All-Dead; keep tier on partial-fail (Quota miss with surviving players).
+
+**Decided?** Pending.
+
+---
+
+## 3. Ship stations
+
+**Question.** What does each ship station actually do?
+
+**Why it matters.** `ShipStation` exists as a generic "claim/release" component. Until each station has a real flow, the ship interior is decoration. Stations are the most natural place to gate co-op coordination (one player drives, another scans, another loads).
+
+**Decisions needed per station type:**
+- **Pilot station** — Does it control travel? Does it require a player to occupy it for travel to start? Or is travel a vote?
+- **Holographic board / planet preview** — How are planet choices presented? Roll-of-three (per BACKLOG #1's `ServerRollNextPlanetChoices`)? Star map with travel cost? Random with re-roll consumable?
+- **Module slot / customization bench** — Cosmetic only, or gameplay-affecting (ship upgrades: bigger inventory, faster travel, ammo refills)?
+- **Vending / restock** — Where do players buy ammo, healing, ship parts they're missing? Tied to deposited money?
+
+**My read.** Treat the ship as a hub, not a UI replacement. Recommendation:
+- Pilot station: **required-occupant model**. Travel starts only when one player presses "Engage" while occupying it. Adds tactility, gives the host station a clear role.
+- Holographic board: **roll-of-three with one re-roll**. Already half-built; just needs UI.
+- Customization: **cosmetic only at first**. Gameplay upgrades open a balancing rabbit hole; defer until the core loop is fun.
+- Restock: **single vending kiosk**, money-driven. Sell back unwanted loot. Don't duplicate the deposit flow; let the same money stat drive both.
+
+**Decided?** Pending.
+
+---
+
+## 4. Teleporter flow
+
+**Question.** Should teleport be automatic (current), interact-to-use, station-controlled, or phase-gated?
+
+**Why it matters.** Auto-teleport feels surprising during launchpad/extraction phases. It also makes carrying loot or bodies awkward (you might teleport mid-haul). Phase-gating it constrains the round shape.
+
+**Options:**
+- **A. Keep it automatic.** Trigger pad teleports on contact. Simple; works today.
+- **B. Press-to-teleport.** Stand on the pad, hold E, get teleported. Removes accidents.
+- **C. Station-controlled.** Only the ship-side pad activates when a crewmate at the right station hits a button. Forces coordination.
+- **D. Phase-gated automatic.** Auto-teleport, but only during certain phases (e.g. Active and Success on planet → ship; Lobby and Transitioning blocked).
+
+**Carrying interactions.** Should you be able to teleport while carrying loot? A body? A dead crewmate?
+
+**My read.** **B (press-to-teleport)** for the planet-side pad with a 1-second hold to confirm; auto for the ship-side pad once the round resolves. Allow teleport with carried loot (it's the whole point); allow carried bodies but emit a chat log so the rest of the crew sees who came back with whom.
+
+**Decided?** Pending.
+
+---
+
+## 5. Carried/deposited loot across travel
+
+**Question.** What happens to carried and deposited loot when the crew travels to a new planet?
+
+**Why it matters.** This was a grooming question on BACKLOG item 1. It affects the entire economy: do players need to commit to depositing before extraction, or can they hoard?
+
+**Options:**
+- **A. Deposited loot persists; carried loot is lost.** Strong incentive to deposit before flying. Punishing for last-second extraction.
+- **B. Both persist.** Travel teleports loot with the player. Easiest from a dev standpoint; risks letting players carry oversized inventories between planets.
+- **C. Deposited persists; carried converts to cash on travel.** Loot turns into money in the team pool when you fly. Removes the "carry forever" hoard while not punishing the player who didn't make it to the deposit zone in time.
+- **D. Both persist, but the ship has a finite cargo bay.** Hard cap on what comes home. Leans into the "salvage" framing.
+
+**My read.** **C** for the first iteration (simple, fair, supports the deposit zone's purpose), with **D** as a stretch goal if you add ship customization (cargo bay upgrade as a meaningful gameplay choice).
+
+**Decided?** Pending.
+
+---
+
+## 6. Objective UX
+
+**Question.** What does the HUD actually say at each phase, and how prominent should objective state be?
+
+**Why it matters.** Today the success/fail copy still assumes rocket assembly. New objective types (`QuotaObjective`, `SurvivalObjective`) reuse this copy and read wrong.
+
+**Decisions needed:**
+- **HUD start of round.** "Find 3 ship parts" / "Reach $500 in deposits" / "Survive 5 minutes" — should it scroll across the screen, or live in a corner?
+- **Mid-objective progress.** Per-part icons? Money counter? Survival timer?
+- **Extraction-ready signal.** When is the crew clear to leave? Does the launchpad change visually? Audio cue?
+- **Success / failure copy.** Per-objective, not "the rocket is assembled."
+- **Compact line vs. dedicated panel.** The current single HUD line is dense; should each objective type get its own widget?
+
+**My read.** Per-objective `BuildHudStatus()` already exists on `RoundObjective` — that's the right seam. Decisions are mostly text and a per-objective icon. Recommend:
+- One persistent HUD widget for primary objective (top-left, replaces current `timerText` content).
+- One toast/banner for extraction-ready ("Launchpad active! Board to extract").
+- Success/failure copy moves into the `RoundObjective` asset itself as a `successText`/`failureText` field.
+
+**Decided?** Pending.
+
+---
+
+## 7. Loot economy and budgets
+
+**Question.** How is loot value distributed per mission?
+
+**Why it matters.** Hand-tuned quotas per planet don't scale. As content grows, you'll want a budget rule that says "this mission guarantees $X minimum value with rarity variance."
+
+**Decisions needed:**
+- **Minimum guaranteed value per objective.** Should the planet always spawn enough loot to clear the quota with margin, or should rarity rolls sometimes leave the crew short?
+- **Rare items: required or optional upside?** If a mission can roll without enough rares, is it a bad luck loss or a "scour the map harder" challenge?
+- **Scaling axis.** Tier? Crew size? Objective type? Or a simple hand-set per-planet number?
+
+**My read.** Use a **budget per-mission model** with a **120% guaranteed minimum and 200% potential ceiling**:
+- Each `PlanetDefinition` declares `quotaTarget` (already exists) and `lootValueBudget` (new).
+- Spawner rolls until total spawned value ≥ 1.2 × `quotaTarget` and ≤ 2.0 × `quotaTarget`.
+- Within the budget, item selection comes from a `LootPool.asset` rolled by rarity weights.
+- Don't scale by crew size for v1 — too easy to game by ghost-joining.
+
+**Decided?** Pending.
+
+---
+
+## 8. Combat and weapons
+
+**Question.** Friendly fire? Weapon role? Ammo persistence?
+
+**Why it matters.** Laser gun and boxing gloves work mechanically but their place in the game isn't decided. Friendly fire in particular changes group dynamics dramatically and constrains future combat content.
+
+**Decisions needed:**
+- **Friendly fire.** On (full PvP), off (no damage between crewmates), or partial (knockback yes, damage no)?
+- **Weapon distribution.** Loot-only (find on planets), shop-only (buy at the ship), mission-tool (provided per round), or rare chaos items (one per run, high impact)?
+- **Ammo and cooldowns.** Reset between rounds? Persist with the weapon? Recharge over time?
+- **Death from a teammate.** If FF is on, does the killer get the body? Does anyone get accountability beyond a chat log?
+
+**My read.** **Partial FF (knockback yes, damage no)** is the sweet spot for a co-op salvage game — it allows funny moments and tactical pushes without "friend just killed me at the launchpad." Weapons as **loot-only with rarity tiers**, ammo persists with the weapon, refilled at a ship vending kiosk (#3) for cash.
+
+**Decided?** Pending.
+
+---
+
+## 9. Hazard pacing and per-planet identity
+
+**Question.** Which hazards belong to which planet, and how do they pace?
+
+**Why it matters.** Today monsters and anomaly orbs spawn generically. Per-planet hazard sets are the cheapest way to make planets feel different (BACKLOG #2 plays into this).
+
+**Decisions needed:**
+- **Per-planet hazard composition.** Should `PlanetDefinition` declare which hazard types are eligible? Should hazards have their own catalog asset?
+- **Time-based escalation.** Do hazards ramp during the round (more spawns, faster movement)? Or stay static?
+- **Counterplay signaling.** Audio cue before a monster aggros? Visual telegraph for anomaly orbs? How much "see it coming" do players get?
+- **Hazard difficulty by tier.** Tier 1 = one slow monster, tier 5 = anomaly fields, etc.?
+
+**My read.** Add a **`PlanetHazardSet.asset`** ScriptableObject referenced from `PlanetDefinition`. It declares spawn rates, eligible hazards, ramp curve. This keeps hazard tuning data-driven (matches the SO-first rule). Per-planet flavor unlocks naturally: "Wraith Halo has anomaly orbs but no monsters; Cobalt Trench has slow monsters but flooding."
+
+**Decided?** Pending.
+
+---
+
+## 10. Dead-player loop
+
+**Question.** Can dead players be revived? What does carrying a body to the ship/launchpad do?
+
+**Why it matters.** Body carrying is built but the loop around it isn't defined. Without rules, dying just means the player spectates and waits — boring.
+
+**Options:**
+- **A. Permadeath per round.** Bodies carried back are cosmetic / for chat banter. Dead players spectate until the next round.
+- **B. Revive at the ship.** Carry the body to a specific ship station (medbay?). Costs money or a consumable. Player respawns.
+- **C. Revive on extraction.** All carried bodies revive automatically when the crew extracts successfully. Bodies left on the planet stay dead.
+- **D. Revive via launchpad.** Bodies dropped on the launchpad before takeoff get the player back; otherwise dead.
+
+**Spectator mechanics.** While dead, the player follows a teammate's camera. Should they be able to ping objects? Voice chat with the living? Whisper-only mode?
+
+**My read.** **C (revive on extraction)** plus **partial spectator interaction** (can ping locations, can voice chat with the living). Reasoning: it makes the carry mechanic load-bearing without adding a station, rewards crews that actually retrieve fallen friends, and gives the dead player a meaningful goal (help the living finish so I revive).
+
+**Decided?** Pending.
+
+---
+
+## 11. UI generation strategy
+
+**Question.** Should `FriendSlopUI` stay procedural, move to prefabs, or use UI Toolkit (UXML)?
+
+**Why it matters.** Five partial files of procedural UI is workable for a prototype, but the next layer of UI work (planet selection screen, station UIs, inventory expansion, settings menu) will balloon those files past readable.
+
+**Options:**
+- **A. Stay procedural.** Lowest churn. Each new screen adds a partial.
+- **B. Move large screens to prefabs.** Menu, planet selection, station dialogs become prefabs assigned via `SerializeField`. HUD stays procedural.
+- **C. UI Toolkit (UXML/USS).** Modern Unity UI; designer-friendly with hot reload; steeper authoring learning curve; mostly orthogonal to existing UGUI code.
+- **D. Hybrid: prefabs + drive from `OnValueChanged` events.** Replace the per-frame `RefreshUi` polling with subscriptions; move composite screens to prefabs.
+
+**My read.** **D**. The polling-architecture cost (every frame rebuilds layout) is the real pain point, not the procedural authoring per se. Move large composite screens to prefabs as you add them; subscribe to `NetworkVariable.OnValueChanged` for per-widget updates; keep the simple HUD widgets procedural for now.
+
+**Decided?** Pending.
+
+---
+
+## 12. Lobby and matchmaking UX
+
+**Question.** How do players find each other?
+
+**Why it matters.** Relay + LAN exist but the join flow is "type a code." For public play, that's friction. For friend play, it's fine.
+
+**Decisions needed:**
+- **Discovery model.** Code-only (today)? Public lobby browser? Friend list from a platform (Steam, etc.)?
+- **Host configuration.** Should the host pick crew size, seed, difficulty, privacy at lobby creation, or are those all defaults?
+- **Ready-up.** Does everyone press Ready before round start, or does the host start whenever they want?
+- **Mid-session join.** Allowed today; should there be a player count cap, a phase restriction (no joining mid-Active?), or a host invite-only toggle?
+
+**My read.** Stay code-based until the game is fun enough to invite strangers. When that day comes, **public lobby browser** > friend list (no platform dependency). Host config at lobby creation: privacy, max crew size. Skip ready-up; host starts the round. Mid-join allowed in Lobby and Transitioning phases only.
+
+**Decided?** Pending.
+
+---
+
+## 13. Chat scope
+
+**Question.** What does chat actually need before public play?
+
+**Why it matters.** Functional but minimal. With strangers, chat needs moderation hooks; with friends, it doesn't.
+
+**Decisions needed:**
+- **Persistence.** Across rounds? Across sessions?
+- **System messages.** Should kills, deposits, deaths, phase transitions appear in chat?
+- **Moderation.** Mute, block, rate-limit, profanity filter?
+- **Voice chat.** In scope, or out?
+
+**My read.** Defer chat polish until lobby/matchmaking decisions land — those will dictate whether chat needs heavy moderation tooling. For friend-only play (current state), keep chat simple: persist within session, add system messages for big events (deposits, deaths, extraction), skip moderation entirely. Voice chat: defer (Steam/Discord will cover it for friend play).
+
+**Decided?** Pending.
+
+---
+
+## Decision dependencies
+
+Some decisions block or enable others. Roughly:
+
+```
+[2. Progression endpoint] ─┬─> [3. Ship stations: pilot]
+                            └─> [11. UI: planet selection screen]
+
+[4. Teleporter flow] ───────> [5. Carried loot across travel]
+
+[7. Loot economy] ──────────> [8. Combat: ammo refills via vending]
+
+[9. Hazard pacing] ─────────> [1. Tier 2 identity]  (hazard set per planet)
+
+[12. Lobby UX] ─────────────> [13. Chat moderation needs]
+```
+
+Suggested decision order if you want to unblock the most downstream work: **2 → 4 → 5 → 11 → 9 → 1**, then the rest.
+
+---
+
+## When to update this doc
+
+- A decision is made → strike through "Pending" and write the choice + rationale on the **Decided?** line.
+- A new gameplay question surfaces in playtest → add a section.
+- Architecture impact → cross-reference [docs/architecture.md](architecture.md).
+- A decision changes a tracked BACKLOG item's scope → update [BACKLOG.md](../BACKLOG.md) at the same time.


### PR DESCRIPTION
## Summary

Follow-up to PR #17 (scene ownership). Two themes: small architectural cleanups identified during the audit, and a working **GameplayDecisions** doc for design grooming.

### Code changes
- **UI**: drop redundant `carriedText` (inventory HUD slots already show item name + value).
- **UI/Core**: replace `FindFirstObjectByType<DayNightCycle>` with a `DayNightCycleRegistry` (mirrors `RoundManagerRegistry` / `LocalPlayerRegistry`). `DayNightCycle` self-registers in `OnNetworkSpawn` / `OnNetworkDespawn`; survives planet-scene unloads cleanly.
- **Hazards**: promote `RoamingMonster._isDead` to `NetworkVariable<bool>` so late-joiners get the correct value via `OnValueChanged`. Removes the now-redundant `DieClientRpc` / `ReviveClientRpc`.
- **Hazards (perf)**: scale `ComputeBodyVisibility` linecasts by distance — 4 samples close, 2 medium, 1 (torso) at long range. Worst case drops from 32 to 8 linecasts/frame with 4 players + 2 monsters.
- **Hazards (refactor)**: split `RoamingMonster.cs` into three partials (main = state machine + lifecycle, `.Perception.cs`, `.Movement.cs`). Main file is now 263 lines (down from 489 baseline).
- **Tests**: ratchet `ArchitectureGuardrailTests` baselines — drop `RoamingMonster.cs` (now under default 400), tighten `FriendSlopUI.cs` (488→477) and `FriendSlopUI.BuildUi.cs` (518→517) to lock in the wins.

### Docs
- New `docs/GameplayDecisions.md` — 13 open design questions for you and your friend, each with context, options with tradeoffs, a recommendation, and a `Decided?` line. Includes a dependency graph for ordering.

### Chore
- `dev/null/` directory was a Windows artifact of git LFS hooks; deleted and added `/dev/` plus `.claude/` to `.gitignore`.

### What's deferred (and why)
A few items from my earlier audit are intentionally not in this PR — each deserves its own focused effort:
- **Pre-emptive splits** of `NetworkLootItem.cs`, `PlayerInteractor.cs`, `FriendSlopUI.BuildUi.cs`, and further `RoundManager.cs` carving — happy to do these as follow-ups if you want CI breathing room.
- **Full asmdef split** (`Core ← Networking ← Gameplay ← UI` per architecture.md D-006) — explicitly called out as "single focused PR."
- **`RoundManager.Instance` migration** — SingletonAudit recommends staged removal, not single sweep.
- **`FriendSlopUI` polling rewrite** — pairs with the prefab move (BACKLOG #11).
- **Test-coverage backfill** — separate dedicated effort.

## Test plan

- [ ] CI: EditMode tests (architecture guardrails will validate file sizes + the new `_isDead` declaration order).
- [ ] CI: PlayMode smoke test.
- [ ] Playtest — start a round, kill a monster, restart the round → monster revives correctly with renderers/collider re-enabled.
- [ ] Playtest — late-join a session where a monster is already dead → late-joiner sees the dead state (renderers off) without needing the RPC.
- [ ] Playtest — sun glare / day/night HUD effects still trigger when looking at the sun (uses the new registry path).
- [ ] Playtest — carrying loot HUD: inventory slots still show item info; the redundant single-line carried text is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)