### PR TITLE
[Bugs] Fix loot pickup + drift on curved planet surface

### DIFF
--- a/Space Game/Assets/Prefabs/PoolLoot/Holo_Tablet.prefab
+++ b/Space Game/Assets/Prefabs/PoolLoot/Holo_Tablet.prefab
@@ -34,7 +34,7 @@ Transform:
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 0.95, y: 0.08, z: 0.65}
+  m_LocalScale: {x: 0.95, y: 0.18, z: 0.65}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
@@ -126,8 +126,8 @@ Rigidbody:
   m_GameObject: {fileID: 4635537996208157398}
   serializedVersion: 5
   m_Mass: 1.8800002
-  m_LinearDamping: 0
-  m_AngularDamping: 0.15
+  m_LinearDamping: 1.5
+  m_AngularDamping: 0.5
   m_CenterOfMass: {x: 0, y: 0, z: 0}
   m_InertiaTensor: {x: 1, y: 1, z: 1}
   m_InertiaRotation: {x: 0, y: 0, z: 0, w: 1}

--- a/Space Game/Assets/Scripts/Loot/NetworkLootItem.Settle.cs
+++ b/Space Game/Assets/Scripts/Loot/NetworkLootItem.Settle.cs
@@ -1,0 +1,97 @@
+using UnityEngine;
+
+namespace FriendSlop.Loot
+{
+    // Sphere gravity keeps applying tangential force to a rigidbody resting on a curved
+    // planet, so flat or low-friction loot drifts forever and never crosses Unity's
+    // auto-sleep threshold. We force a freeze on the server once the body has had time
+    // to land; collisions wake it back up.
+    public partial class NetworkLootItem
+    {
+        // Toggle to dump server-side physics state for every loot item. Verbose; expect to
+        // disable after diagnosing a specific bug.
+        private const bool LogSettleDiagnostics = true;
+
+        // Velocity bands for an "early" freeze - if the body is genuinely calm we settle
+        // sooner than the timeout. Generous because a flat box on a curved sphere produces
+        // continuous narrowphase jitter that never crosses Unity's auto-sleep threshold.
+        private const float SettleLinearSpeed = 1.0f;
+        private const float SettleAngularSpeed = 2.0f;
+        private const float SettleEarlyMinSeconds = 0.4f;
+
+        // Hard timeout: regardless of velocity, freeze after this long. Catches the
+        // pathological "vibrates forever" case.
+        private const float SettleForceTimeoutSeconds = 1.5f;
+
+        // Wake threshold (squared impulse). Below this we treat collision events as
+        // residual contact noise and stay frozen.
+        private const float SettleWakeImpulseSqr = 1.0f;
+
+        private float _serverActiveSince = -1f;
+        private float _nextSettleDiagnosticAt;
+
+        private void FixedUpdate()
+        {
+            if (!IsServer) return;
+            if (body == null || body.isKinematic) return;
+            if (IsCarried.Value || IsDeposited.Value) return;
+
+            if (_serverActiveSince < 0f)
+            {
+                _serverActiveSince = Time.time;
+                _nextSettleDiagnosticAt = Time.time + 0.5f;
+            }
+
+            var elapsed = Time.time - _serverActiveSince;
+            var linSpeed = body.linearVelocity.magnitude;
+            var angSpeed = body.angularVelocity.magnitude;
+
+            if (LogSettleDiagnostics && Time.time >= _nextSettleDiagnosticAt)
+            {
+                _nextSettleDiagnosticAt = Time.time + 0.5f;
+                Debug.Log($"[Loot.Settle] {itemName} active={elapsed:F2}s lin={linSpeed:F2} ang={angSpeed:F2} pos={body.position} kinematic={body.isKinematic}");
+            }
+
+            var calmEnoughForEarlyFreeze = linSpeed < SettleLinearSpeed && angSpeed < SettleAngularSpeed;
+            var hitForceTimeout = elapsed >= SettleForceTimeoutSeconds;
+            var hitEarlyFreeze = elapsed >= SettleEarlyMinSeconds && calmEnoughForEarlyFreeze;
+
+            if (hitForceTimeout || hitEarlyFreeze)
+            {
+                if (LogSettleDiagnostics)
+                {
+                    var reason = hitForceTimeout ? "timeout" : "calm";
+                    Debug.Log($"[Loot.Settle] FREEZE {itemName} reason={reason} elapsed={elapsed:F2}s lin={linSpeed:F2} ang={angSpeed:F2}");
+                }
+                FreezeAtRest();
+            }
+        }
+
+        private void FreezeAtRest()
+        {
+            if (body == null) return;
+            body.linearVelocity = Vector3.zero;
+            body.angularVelocity = Vector3.zero;
+            body.isKinematic = true;
+            if (sphericalGravity != null) sphericalGravity.enabled = false;
+            _serverActiveSince = -1f;
+        }
+
+        private void TryWakeFromCollision(Collision collision)
+        {
+            if (body == null || !body.isKinematic) return;
+            var impulseSqr = collision.impulse.sqrMagnitude;
+            if (impulseSqr < SettleWakeImpulseSqr) return;
+
+            if (LogSettleDiagnostics)
+            {
+                var otherName = collision.collider != null ? collision.collider.name : "?";
+                Debug.Log($"[Loot.Settle] WAKE {itemName} by {otherName} impulse^2={impulseSqr:F3}");
+            }
+
+            body.isKinematic = false;
+            if (sphericalGravity != null) sphericalGravity.enabled = true;
+            _serverActiveSince = -1f;
+        }
+    }
+}

--- a/Space Game/Assets/Scripts/Loot/NetworkLootItem.cs
+++ b/Space Game/Assets/Scripts/Loot/NetworkLootItem.cs
@@ -241,14 +241,19 @@ namespace FriendSlop.Loot
             var origin = player.PlayerCamera != null
                 ? player.PlayerCamera.transform.position
                 : player.transform.position + player.transform.up * 1.1f;
-            var target = GetServerPickupTargetPoint();
+            var target = GetServerPickupTargetPoint(origin);
             if ((target - origin).sqrMagnitude > ServerPickupMaxDistance * ServerPickupMaxDistance)
                 return false;
 
             return HasClearPickupLine(player.transform.root, origin, transform.root, target);
         }
 
-        private Vector3 GetServerPickupTargetPoint()
+        // Returns the point on the item closest to the camera. We previously used the bounds
+        // center, but for flat items resting on a curved planet that center sits at (or just
+        // below) the surface — the LOS raycast then hits the planet right before reaching the
+        // destination and silently rejects the pickup. Aiming at the closest surface point of
+        // the bounds keeps the ray endpoint above the ground and the ray itself in air.
+        private Vector3 GetServerPickupTargetPoint(Vector3 origin)
         {
             var hasBounds = false;
             var bounds = default(Bounds);
@@ -270,7 +275,7 @@ namespace FriendSlop.Loot
                 }
             }
 
-            return hasBounds ? bounds.center : transform.position;
+            return hasBounds ? bounds.ClosestPoint(origin) : transform.position;
         }
 
         private static bool HasClearPickupLine(Transform playerRoot, Vector3 origin, Transform itemRoot, Vector3 target)
@@ -580,6 +585,9 @@ namespace FriendSlop.Loot
         private void OnCollisionEnter(Collision collision)
         {
             if (!IsServer || IsCarried.Value || IsDeposited.Value) return;
+
+            TryWakeFromCollision(collision);
+
             if (Time.time < _monsterHitCooldown) return;
             if (body == null || body.linearVelocity.magnitude < 3f) return;
 


### PR DESCRIPTION
## Summary
- Fix server-side pickup LOS silently rejecting flat items (Holo Tablet)
- Stop sphere gravity from dragging loot forever across the curved surface
- Thicken Holo_Tablet so it actually has a contact patch

## What changed

**Pickup LOS** — `CanServerReachForPickup` raycasts from the player camera to `bounds.center` of the item. For a flat tablet sitting on the planet, that center sits at/below the surface, so the ray hit the planet right before the destination and rejected the pickup with no feedback. Now we aim at `bounds.ClosestPoint(camera)` — the face nearest the camera — keeping the ray endpoint above ground.

**Settle-to-kinematic** — New `NetworkLootItem.Settle.cs` (partial). Sphere gravity applies a tangential force every FixedUpdate, so a flat collider on a curved surface never crosses Unity's auto-sleep threshold. We force a freeze on a 1.5s timeout (or earlier if velocity is genuinely calm), and wake on collision impulse² > 1.0 (player bumps, throws, drops, monsters).

**Prefab tweak** — `Holo_Tablet`: thickness Y `0.08 → 0.18`, linear damping `0 → 1.5`, angular damping `0.15 → 0.5`.

## Reviewer notes

- `LogSettleDiagnostics = true` in `NetworkLootItem.Settle.cs:13` is on for playtest. Flip to `false` before merging once the fix is verified.
- Affects all loot, not just Holo_Tablet. The pickup-LOS bug applied to any item flat enough that `bounds.center` sat near the surface; the settle change applies to every server-side loot rigidbody.
- No tests added — settle behavior is timing- and physics-coupled and would be flaky in EditMode; the diagnostic logs are the verification path for now.

## Test plan
- [ ] Start a session, walk up to a Holo Tablet on the planet, press E — pickup is immediate
- [ ] Console shows periodic `[Loot.Settle]` lines and a `FREEZE` entry per item within ~1.5s of spawn
- [ ] Throw or drop loot — it slides, slows, and freezes without drifting off
- [ ] Bump a frozen item with the player or another item — it wakes and resumes physics
- [ ] Confirm no regression on already-working loot (Rusty Toolbox, Cryo Diamond)

🤖 Generated with [Claude Code](https://claude.com/claude-code)