### PR TITLE
ci: drop Linux/macOS build targets to cut LFS + CI cost

### DIFF
--- a/.github/workflows/build-and-deploy-itch.yml
+++ b/.github/workflows/build-and-deploy-itch.yml
@@ -57,7 +57,23 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          lfs: true
+          lfs: false
+
+      - name: Build LFS object id list
+        shell: bash
+        run: git lfs ls-files --long | cut -d ' ' -f1 | sort > .lfs-assets-id
+
+      - name: Restore LFS object cache
+        uses: actions/cache@v5
+        with:
+          path: .git/lfs/objects
+          key: ${{ runner.os }}-lfs-${{ hashFiles('.lfs-assets-id') }}
+          restore-keys: |
+            ${{ runner.os }}-lfs-
+
+      - name: Fetch LFS objects (cache-aware)
+        shell: bash
+        run: git lfs pull
 
       - name: Check Unity license secrets
         uses: ./.github/actions/check-unity-license
@@ -110,7 +126,23 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          lfs: true
+          lfs: false
+
+      - name: Build LFS object id list
+        shell: bash
+        run: git lfs ls-files --long | cut -d ' ' -f1 | sort > .lfs-assets-id
+
+      - name: Restore LFS object cache
+        uses: actions/cache@v5
+        with:
+          path: .git/lfs/objects
+          key: ${{ runner.os }}-lfs-${{ hashFiles('.lfs-assets-id') }}
+          restore-keys: |
+            ${{ runner.os }}-lfs-
+
+      - name: Fetch LFS objects (cache-aware)
+        shell: bash
+        run: git lfs pull
 
       - name: Check Unity license secrets
         uses: ./.github/actions/check-unity-license
@@ -190,7 +222,23 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          lfs: true
+          lfs: false
+
+      - name: Build LFS object id list
+        shell: bash
+        run: git lfs ls-files --long | cut -d ' ' -f1 | sort > .lfs-assets-id
+
+      - name: Restore LFS object cache
+        uses: actions/cache@v5
+        with:
+          path: .git/lfs/objects
+          key: ${{ runner.os }}-lfs-${{ hashFiles('.lfs-assets-id') }}
+          restore-keys: |
+            ${{ runner.os }}-lfs-
+
+      - name: Fetch LFS objects (cache-aware)
+        shell: bash
+        run: git lfs pull
 
       - name: Check Unity license secrets
         uses: ./.github/actions/check-unity-license
@@ -260,7 +308,23 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          lfs: true
+          lfs: false
+
+      - name: Build LFS object id list
+        shell: bash
+        run: git lfs ls-files --long | cut -d ' ' -f1 | sort > .lfs-assets-id
+
+      - name: Restore LFS object cache
+        uses: actions/cache@v5
+        with:
+          path: .git/lfs/objects
+          key: ${{ runner.os }}-lfs-${{ hashFiles('.lfs-assets-id') }}
+          restore-keys: |
+            ${{ runner.os }}-lfs-
+
+      - name: Fetch LFS objects (cache-aware)
+        shell: bash
+        run: git lfs pull
 
       - name: Check Unity license secrets
         uses: ./.github/actions/check-unity-license

--- a/.github/workflows/build-and-deploy-itch.yml
+++ b/.github/workflows/build-and-deploy-itch.yml
@@ -57,29 +57,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          lfs: false
-
-      - name: Initialize Git LFS for this checkout
-        shell: bash
-        run: git lfs install --local
-
-      - name: Build LFS object id list
-        shell: bash
-        run: git lfs ls-files --long | cut -d ' ' -f1 | sort > .lfs-assets-id
-
-      - name: Restore LFS object cache
-        uses: actions/cache@v5
-        with:
-          path: .git/lfs/objects
-          key: ${{ runner.os }}-lfs-${{ hashFiles('.lfs-assets-id') }}
-          restore-keys: |
-            ${{ runner.os }}-lfs-
-
-      - name: Fetch LFS objects (cache-aware)
-        shell: bash
-        run: |
-          set -euo pipefail
-          git lfs pull
+          lfs: true
 
       - name: Check Unity license secrets
         uses: ./.github/actions/check-unity-license
@@ -132,29 +110,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          lfs: false
-
-      - name: Initialize Git LFS for this checkout
-        shell: bash
-        run: git lfs install --local
-
-      - name: Build LFS object id list
-        shell: bash
-        run: git lfs ls-files --long | cut -d ' ' -f1 | sort > .lfs-assets-id
-
-      - name: Restore LFS object cache
-        uses: actions/cache@v5
-        with:
-          path: .git/lfs/objects
-          key: ${{ runner.os }}-lfs-${{ hashFiles('.lfs-assets-id') }}
-          restore-keys: |
-            ${{ runner.os }}-lfs-
-
-      - name: Fetch LFS objects (cache-aware)
-        shell: bash
-        run: |
-          set -euo pipefail
-          git lfs pull
+          lfs: true
 
       - name: Check Unity license secrets
         uses: ./.github/actions/check-unity-license
@@ -234,29 +190,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          lfs: false
-
-      - name: Initialize Git LFS for this checkout
-        shell: bash
-        run: git lfs install --local
-
-      - name: Build LFS object id list
-        shell: bash
-        run: git lfs ls-files --long | cut -d ' ' -f1 | sort > .lfs-assets-id
-
-      - name: Restore LFS object cache
-        uses: actions/cache@v5
-        with:
-          path: .git/lfs/objects
-          key: ${{ runner.os }}-lfs-${{ hashFiles('.lfs-assets-id') }}
-          restore-keys: |
-            ${{ runner.os }}-lfs-
-
-      - name: Fetch LFS objects (cache-aware)
-        shell: bash
-        run: |
-          set -euo pipefail
-          git lfs pull
+          lfs: true
 
       - name: Check Unity license secrets
         uses: ./.github/actions/check-unity-license
@@ -320,29 +254,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          lfs: false
-
-      - name: Initialize Git LFS for this checkout
-        shell: bash
-        run: git lfs install --local
-
-      - name: Build LFS object id list
-        shell: bash
-        run: git lfs ls-files --long | cut -d ' ' -f1 | sort > .lfs-assets-id
-
-      - name: Restore LFS object cache
-        uses: actions/cache@v5
-        with:
-          path: .git/lfs/objects
-          key: ${{ runner.os }}-lfs-${{ hashFiles('.lfs-assets-id') }}
-          restore-keys: |
-            ${{ runner.os }}-lfs-
-
-      - name: Fetch LFS objects (cache-aware)
-        shell: bash
-        run: |
-          set -euo pipefail
-          git lfs pull
+          lfs: true
 
       - name: Check Unity license secrets
         uses: ./.github/actions/check-unity-license

--- a/.github/workflows/build-and-deploy-itch.yml
+++ b/.github/workflows/build-and-deploy-itch.yml
@@ -59,6 +59,10 @@ jobs:
           fetch-depth: 0
           lfs: false
 
+      - name: Initialize Git LFS for this checkout
+        shell: bash
+        run: git lfs install --local
+
       - name: Build LFS object id list
         shell: bash
         run: git lfs ls-files --long | cut -d ' ' -f1 | sort > .lfs-assets-id
@@ -73,7 +77,9 @@ jobs:
 
       - name: Fetch LFS objects (cache-aware)
         shell: bash
-        run: git lfs pull
+        run: |
+          set -euo pipefail
+          git lfs pull
 
       - name: Check Unity license secrets
         uses: ./.github/actions/check-unity-license
@@ -128,6 +134,10 @@ jobs:
           fetch-depth: 0
           lfs: false
 
+      - name: Initialize Git LFS for this checkout
+        shell: bash
+        run: git lfs install --local
+
       - name: Build LFS object id list
         shell: bash
         run: git lfs ls-files --long | cut -d ' ' -f1 | sort > .lfs-assets-id
@@ -142,7 +152,9 @@ jobs:
 
       - name: Fetch LFS objects (cache-aware)
         shell: bash
-        run: git lfs pull
+        run: |
+          set -euo pipefail
+          git lfs pull
 
       - name: Check Unity license secrets
         uses: ./.github/actions/check-unity-license
@@ -224,6 +236,10 @@ jobs:
           fetch-depth: 0
           lfs: false
 
+      - name: Initialize Git LFS for this checkout
+        shell: bash
+        run: git lfs install --local
+
       - name: Build LFS object id list
         shell: bash
         run: git lfs ls-files --long | cut -d ' ' -f1 | sort > .lfs-assets-id
@@ -238,7 +254,9 @@ jobs:
 
       - name: Fetch LFS objects (cache-aware)
         shell: bash
-        run: git lfs pull
+        run: |
+          set -euo pipefail
+          git lfs pull
 
       - name: Check Unity license secrets
         uses: ./.github/actions/check-unity-license
@@ -296,12 +314,6 @@ jobs:
           - targetPlatform: StandaloneWindows64
             itchChannel: windows
             label: Windows
-          - targetPlatform: StandaloneLinux64
-            itchChannel: linux
-            label: Linux
-          - targetPlatform: StandaloneOSX
-            itchChannel: mac
-            label: macOS
 
     steps:
       - name: Checkout
@@ -309,6 +321,10 @@ jobs:
         with:
           fetch-depth: 0
           lfs: false
+
+      - name: Initialize Git LFS for this checkout
+        shell: bash
+        run: git lfs install --local
 
       - name: Build LFS object id list
         shell: bash
@@ -324,7 +340,9 @@ jobs:
 
       - name: Fetch LFS objects (cache-aware)
         shell: bash
-        run: git lfs pull
+        run: |
+          set -euo pipefail
+          git lfs pull
 
       - name: Check Unity license secrets
         uses: ./.github/actions/check-unity-license
@@ -436,12 +454,6 @@ jobs:
           - targetPlatform: StandaloneWindows64
             itchChannel: windows
             label: Windows
-          - targetPlatform: StandaloneLinux64
-            itchChannel: linux
-            label: Linux
-          - targetPlatform: StandaloneOSX
-            itchChannel: mac
-            label: macOS
     environment:
       name: itch-production
       url: https://theschlote.itch.io/friend-slop


### PR DESCRIPTION
## Summary

This repo is brushing against GitHub's free Git LFS bandwidth quota. The single largest contributor on the workflow side is the `build-player` matrix, which spins up **three** parallel `ubuntu-22.04` jobs (Windows / Linux / macOS), each doing its own `git lfs` checkout. The same logic applies to the `deploy-itch` matrix.

For a 2-person Unity project where only Windows is actually used by the dev + playtester, those extra builders are pure cost — CI minutes, artifact storage, and a 3× cold-cache LFS bandwidth multiplier.

### What changed

- Removed `StandaloneLinux64` and `StandaloneOSX` entries from the `build-player` and `deploy-itch` matrices.
- LFS-dependent jobs (`editmode-tests`, `playmode-tests`, `validate-scenes`, `build-player`) continue to check out with `lfs: true` — same as before this PR.

### What did **not** ship (and why)

An earlier revision of this PR added per-object LFS caching (`actions/cache` on `.git/lfs/objects`, keyed by `git lfs ls-files`) to make warm runs cost zero LFS bandwidth. That pattern failed in this repo's environment with `git lfs pull` exit code 2, and the authenticated Actions logs aren't reachable from the agent session that wrote this PR, so root cause couldn't be pinned down. Reverted to keep CI green; can be revisited in a follow-up with verbose `git lfs pull -v` capture for diagnosis.

### Expected savings

- CI minutes for `build-player`: ~3× → 1×
- Build artifact storage (14-day retention): ~3× → 1×
- `build-player` LFS bandwidth: ~3× → 1× (one builder, one pull)
- `deploy-itch` runs: only on `main` pushes, so unchanged for PR runs

### Bigger savings still available (future PRs)

- **Per-object LFS cache** (deferred — see above).
- **Move LFS storage off GitHub** — e.g., Azure DevOps Repos (free, unlimited LFS) via `.lfsconfig`, keeping code/PRs/CI on GitHub. ~1 hour of setup.
- **Audit what's in LFS** — `.psd`/`.blend` source art and reference videos often don't need to be version-controlled; moving them to shared cloud storage shrinks both storage and bandwidth.

## Test plan

- [ ] All three Unity jobs (`editmode-tests`, `playmode-tests`, `validate-scenes`) pass on this branch.
- [ ] `build-player` runs once (Windows) and uploads a Windows artifact.
- [ ] `deploy-itch` matrix evaluates to a single Windows job (visible on a `main` push; not exercised on this PR).