### PR TITLE
ci: path filters + skip build on PRs + per-object LFS cache

### DIFF
--- a/.github/workflows/build-and-deploy-itch.yml
+++ b/.github/workflows/build-and-deploy-itch.yml
@@ -4,9 +4,19 @@ on:
   push:
     branches:
       - main
+    paths:
+      - 'Space Game/**'
+      - '.github/workflows/build-and-deploy-itch.yml'
+      - '.github/actions/**'
+      - 'tools/**'
   pull_request:
     branches:
       - main
+    paths:
+      - 'Space Game/**'
+      - '.github/workflows/build-and-deploy-itch.yml'
+      - '.github/actions/**'
+      - 'tools/**'
   merge_group:
   workflow_dispatch:
 
@@ -53,11 +63,50 @@ jobs:
     timeout-minutes: 25
 
     steps:
-      - name: Checkout
+      - name: Checkout (code only, no LFS yet)
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          lfs: true
+          lfs: false
+
+      - name: Initialize Git LFS for this checkout
+        shell: bash
+        run: git lfs install --local
+
+      - name: Build LFS object id list
+        shell: bash
+        run: git lfs ls-files --long | cut -d ' ' -f1 | sort > .lfs-assets-id
+
+      - name: Restore LFS object cache
+        uses: actions/cache@v5
+        with:
+          path: .git/lfs/objects
+          key: ${{ runner.os }}-lfs-${{ hashFiles('.lfs-assets-id') }}
+          restore-keys: |
+            ${{ runner.os }}-lfs-
+
+      - name: Fetch LFS objects (cache-aware) with diagnostics
+        shell: bash
+        run: |
+          set -euxo pipefail
+          git lfs env
+          echo "::group::LFS tracked file summary"
+          echo "Tracked LFS files: $(git lfs ls-files --long | wc -l)"
+          git lfs ls-files --long | head -5 || true
+          echo "::endgroup::"
+          echo "::group::Pre-pull cache state"
+          if [ -d .git/lfs/objects ]; then
+            du -sh .git/lfs/objects 2>/dev/null || true
+            echo "Cached objects: $(find .git/lfs/objects -type f 2>/dev/null | wc -l)"
+          else
+            echo "No cache directory (cold cache)"
+          fi
+          echo "::endgroup::"
+          git lfs pull
+          echo "::group::Post-pull cache state"
+          du -sh .git/lfs/objects 2>/dev/null || true
+          echo "Cached objects: $(find .git/lfs/objects -type f 2>/dev/null | wc -l)"
+          echo "::endgroup::"
 
       - name: Check Unity license secrets
         uses: ./.github/actions/check-unity-license
@@ -106,11 +155,50 @@ jobs:
     timeout-minutes: 25
 
     steps:
-      - name: Checkout
+      - name: Checkout (code only, no LFS yet)
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          lfs: true
+          lfs: false
+
+      - name: Initialize Git LFS for this checkout
+        shell: bash
+        run: git lfs install --local
+
+      - name: Build LFS object id list
+        shell: bash
+        run: git lfs ls-files --long | cut -d ' ' -f1 | sort > .lfs-assets-id
+
+      - name: Restore LFS object cache
+        uses: actions/cache@v5
+        with:
+          path: .git/lfs/objects
+          key: ${{ runner.os }}-lfs-${{ hashFiles('.lfs-assets-id') }}
+          restore-keys: |
+            ${{ runner.os }}-lfs-
+
+      - name: Fetch LFS objects (cache-aware) with diagnostics
+        shell: bash
+        run: |
+          set -euxo pipefail
+          git lfs env
+          echo "::group::LFS tracked file summary"
+          echo "Tracked LFS files: $(git lfs ls-files --long | wc -l)"
+          git lfs ls-files --long | head -5 || true
+          echo "::endgroup::"
+          echo "::group::Pre-pull cache state"
+          if [ -d .git/lfs/objects ]; then
+            du -sh .git/lfs/objects 2>/dev/null || true
+            echo "Cached objects: $(find .git/lfs/objects -type f 2>/dev/null | wc -l)"
+          else
+            echo "No cache directory (cold cache)"
+          fi
+          echo "::endgroup::"
+          git lfs pull
+          echo "::group::Post-pull cache state"
+          du -sh .git/lfs/objects 2>/dev/null || true
+          echo "Cached objects: $(find .git/lfs/objects -type f 2>/dev/null | wc -l)"
+          echo "::endgroup::"
 
       - name: Check Unity license secrets
         uses: ./.github/actions/check-unity-license
@@ -186,11 +274,50 @@ jobs:
     timeout-minutes: 25
 
     steps:
-      - name: Checkout
+      - name: Checkout (code only, no LFS yet)
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          lfs: true
+          lfs: false
+
+      - name: Initialize Git LFS for this checkout
+        shell: bash
+        run: git lfs install --local
+
+      - name: Build LFS object id list
+        shell: bash
+        run: git lfs ls-files --long | cut -d ' ' -f1 | sort > .lfs-assets-id
+
+      - name: Restore LFS object cache
+        uses: actions/cache@v5
+        with:
+          path: .git/lfs/objects
+          key: ${{ runner.os }}-lfs-${{ hashFiles('.lfs-assets-id') }}
+          restore-keys: |
+            ${{ runner.os }}-lfs-
+
+      - name: Fetch LFS objects (cache-aware) with diagnostics
+        shell: bash
+        run: |
+          set -euxo pipefail
+          git lfs env
+          echo "::group::LFS tracked file summary"
+          echo "Tracked LFS files: $(git lfs ls-files --long | wc -l)"
+          git lfs ls-files --long | head -5 || true
+          echo "::endgroup::"
+          echo "::group::Pre-pull cache state"
+          if [ -d .git/lfs/objects ]; then
+            du -sh .git/lfs/objects 2>/dev/null || true
+            echo "Cached objects: $(find .git/lfs/objects -type f 2>/dev/null | wc -l)"
+          else
+            echo "No cache directory (cold cache)"
+          fi
+          echo "::endgroup::"
+          git lfs pull
+          echo "::group::Post-pull cache state"
+          du -sh .git/lfs/objects 2>/dev/null || true
+          echo "Cached objects: $(find .git/lfs/objects -type f 2>/dev/null | wc -l)"
+          echo "::endgroup::"
 
       - name: Check Unity license secrets
         uses: ./.github/actions/check-unity-license
@@ -240,6 +367,7 @@ jobs:
       - editmode-tests
       - playmode-tests
       - validate-scenes
+    if: github.event_name != 'pull_request'
     timeout-minutes: 60
     strategy:
       fail-fast: false
@@ -250,11 +378,50 @@ jobs:
             label: Windows
 
     steps:
-      - name: Checkout
+      - name: Checkout (code only, no LFS yet)
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          lfs: true
+          lfs: false
+
+      - name: Initialize Git LFS for this checkout
+        shell: bash
+        run: git lfs install --local
+
+      - name: Build LFS object id list
+        shell: bash
+        run: git lfs ls-files --long | cut -d ' ' -f1 | sort > .lfs-assets-id
+
+      - name: Restore LFS object cache
+        uses: actions/cache@v5
+        with:
+          path: .git/lfs/objects
+          key: ${{ runner.os }}-lfs-${{ hashFiles('.lfs-assets-id') }}
+          restore-keys: |
+            ${{ runner.os }}-lfs-
+
+      - name: Fetch LFS objects (cache-aware) with diagnostics
+        shell: bash
+        run: |
+          set -euxo pipefail
+          git lfs env
+          echo "::group::LFS tracked file summary"
+          echo "Tracked LFS files: $(git lfs ls-files --long | wc -l)"
+          git lfs ls-files --long | head -5 || true
+          echo "::endgroup::"
+          echo "::group::Pre-pull cache state"
+          if [ -d .git/lfs/objects ]; then
+            du -sh .git/lfs/objects 2>/dev/null || true
+            echo "Cached objects: $(find .git/lfs/objects -type f 2>/dev/null | wc -l)"
+          else
+            echo "No cache directory (cold cache)"
+          fi
+          echo "::endgroup::"
+          git lfs pull
+          echo "::group::Post-pull cache state"
+          du -sh .git/lfs/objects 2>/dev/null || true
+          echo "Cached objects: $(find .git/lfs/objects -type f 2>/dev/null | wc -l)"
+          echo "::endgroup::"
 
       - name: Check Unity license secrets
         uses: ./.github/actions/check-unity-license


### PR DESCRIPTION
## Summary

Stacks on top of #25 (Windows-only matrix). Three independent optimizations to further reduce LFS bandwidth and CI time for a 2-person project.

### 1. Path filters on the workflow trigger

`push` and `pull_request` to `main` now only fire when files under these paths change:

- `Space Game/**` (the Unity project)
- `.github/workflows/build-and-deploy-itch.yml`
- `.github/actions/**`
- `tools/**`

PRs that touch only `README.md`, `BACKLOG.md`, `RELEASE_NOTES.md`, `docs/`, `.gitignore`, etc. won't spin up Unity at all. `merge_group` is left without path filters so the merge queue always runs the full suite.

### 2. Skip `build-player` on pull requests

Added `if: github.event_name != 'pull_request'` to the `build-player` job. PRs still run the three Unity test jobs (EditMode / PlayMode / scene validation) as the merge gate, but the full Windows build now runs only on push to `main` where it feeds the itch deploy.

**Trade-off:** loses PR-time build verification, in exchange for ~1 fewer Unity job per PR (saves ~5–10 min of CI minutes + one LFS pull).

### 3. Per-object LFS cache (retry of the pattern dropped in #25)

Each of the four LFS-using jobs (`editmode-tests`, `playmode-tests`, `validate-scenes`, `build-player`) now does:

1. Checkout with `lfs: false`
2. `git lfs install --local`
3. Build a sorted list of LFS object ids from `git lfs ls-files`
4. `actions/cache@v5` restore of `.git/lfs/objects`, keyed by `hashFiles('.lfs-assets-id')` with an OS-scoped restore-key fallback
5. `git lfs pull` under `set -euxo pipefail` with `git lfs env`, pre-/post-cache size, and file counts wrapped in `::group::`s

On a warm cache (asset list unchanged between runs) the pull is a no-op for LFS bandwidth. On partial change, the restore-key falls back to the prior run's blobs and `git lfs pull` only fetches the delta.

This is the same pattern the first commit of #25 tried; that attempt was blocked by an LFS quota refusal (now resolved) that masked whether the pattern itself worked. Verbose diagnostics are in place so if it fails this time, the logs will show a real reason instead of just "exit code 2".

## Expected savings (on top of PR #25)

- **PRs that only touch docs/markdown:** zero Unity jobs (path filter skips the workflow entirely)
- **PRs that touch Unity code/assets:** 3 Unity jobs instead of 4, each pulling near-zero LFS bandwidth on cache hits
- **Pushes to main:** 4 Unity jobs total (3 tests + 1 build), all cache-aware

## Test plan

- [ ] Push commits to verify CI triggers on Unity changes and skips on doc-only changes (first PR commit changes `.github/workflows/...` so this run itself will trigger)
- [ ] Verify "Build Windows player" job is absent on this PR (only Unity test jobs should run)
- [ ] Confirm the new "Fetch LFS objects (cache-aware) with diagnostics" step succeeds on a cold cache
- [ ] On a subsequent run with no asset changes, verify the cache hits and `git lfs pull` reports near-zero bandwidth
- [ ] Push a commit that only modifies `README.md` (after merge) to confirm the workflow does not run

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lm64W5sQ8BYLznTYkWU3p7)_