### PR TITLE
[Docs/Architecture] Interiors codification + vendor-quarantine policy (16a, D-012/D-013, §17)

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -315,6 +315,8 @@ Staged deliberately. **17a–17c change no history and are safe to do unilateral
 - Add the quarantine scaffold so the convention exists: `Assets/ThirdParty/.gitkeep` (+ `.meta`) and a one-line `Assets/ThirdParty/README.md` pointing at D-012. No pack moves yet.
 - Audit `.gitattributes` for binary extensions the current packs use that aren't LFS-tracked (e.g. `.exr`, `.hdr`, `.tif`, `.bmp`); extend coverage if any are committed as raw text. (Do **not** retroactively migrate yet — that's 17d.)
 
+**Status 2026-05-15:** Scaffold landed (`Assets/ThirdParty/` + `README.md` pointing at D-012/D-013, with valid Unity `.meta`s). `.gitattributes` audit done and **clean** — no committed binary extension on `main` *or* the friend branches falls outside the existing LFS list (png/jpg/jpeg/tga/psd/fbx/blend/wav/mp3/ogg/mp4/mov). Confirms the bloat is 100% re-imported text (`.meta`/`.prefab`/`.mat`/`.asset` YAML), so the fix is quarantine + import-once (D-012/D-013), not more LFS. No `.gitattributes` change needed. Remaining 17a item: communicate the new flow to the friend before the next branch is cut.
+
 ### 17b. Inventory & per-pack decision (no history change)
 
 For each pack — `HIVEMIND`, `LowPolyInterior`, `LowPolyInterior2`, `Plugins/Microdetail`, `YughuesFreeRockMaterials`, `_Recovery`, and the friend-branch-only `LowPolyMegaBundle` — classify **keep / relocate / drop** by evidence, not assumption:

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -301,3 +301,57 @@ After each split: drop the file's entry from `ExistingOversizedRuntimeFiles` if 
 These need a human in the editor; queued for the next playtest pass.
 
 - Run `Tools/Friend Slop/Repair Scene Wiring` once to delete the stale ship root from `FriendSlopPrototype.unity` (the wiring repair was updated to handle this on its next run). After running, re-enable `ValidateBootstrapDoesNotOwnShipInterior` in `PlanetSceneValidator.TryValidate`.
+
+## 17. Vendor quarantine + branch reconciliation (architecture D-012/D-013)
+
+**This is the current top priority** (see `docs/architecture.md` roadmap banner). Vendor packs already on `main` total ~12,200 files (`LowPolyInterior2` 9,006, `LowPolyInterior` 1,714, `Plugins/Microdetail` 874, `HIVEMIND` 471, `YughuesFreeRockMaterials` 162) vs ~360 for our own `Prefabs/`. Three friend branches re-import overlapping copies of these, producing 1M+ line diffs, 13–15-file mutual conflicts, a 978 MB `.git`, and the recurring LFS-cost firefight. Goal: make every contribution reviewable and mergeable again without throwing away the friend's real work.
+
+Staged deliberately. **17a–17c change no history and are safe to do unilaterally. 17d rewrites history and is explicitly a coordinated, gated step. 17e depends on 17c.**
+
+### 17a. Stop the bleeding (no history change — do first)
+
+- Land the D-012/D-013 policy (this commit: `architecture.md`, `CLAUDE.md`, this section).
+- Tell the friend the new flow before they cut another branch: short-lived branch off fresh `main`, code + `.asset` only, vendor packs are separate import-once PRs, rebase before review.
+- Add the quarantine scaffold so the convention exists: `Assets/ThirdParty/.gitkeep` (+ `.meta`) and a one-line `Assets/ThirdParty/README.md` pointing at D-012. No pack moves yet.
+- Audit `.gitattributes` for binary extensions the current packs use that aren't LFS-tracked (e.g. `.exr`, `.hdr`, `.tif`, `.bmp`); extend coverage if any are committed as raw text. (Do **not** retroactively migrate yet — that's 17d.)
+
+### 17b. Inventory & per-pack decision (no history change)
+
+For each pack — `HIVEMIND`, `LowPolyInterior`, `LowPolyInterior2`, `Plugins/Microdetail`, `YughuesFreeRockMaterials`, `_Recovery`, and the friend-branch-only `LowPolyMegaBundle` — classify **keep / relocate / drop** by evidence, not assumption:
+
+- Extract the pack's asset GUIDs (`*.meta` `guid:`), then grep `Assets/{Scenes,Prefabs,Resources,Scripts}` and our `.asset` files for those GUIDs. Zero references in shipped content ⇒ drop candidate.
+- Near-certain drops to verify first: `_Recovery/` (2 files, `0.unity` — a Unity crash-recovery scene dump, never referenced) and `LowPolyMegaBundle` (friend-branch-only, superseded by the split LowPoly packs). Confirm with the GUID grep before deleting.
+- Output: a table in this section — pack → file count → decision → referencing scenes/prefabs.
+
+### 17c. Relocate kept packs (working-tree move — history preserved)
+
+For each **keep**/**relocate** pack, one PR per pack (or one tight "relocate vendor" PR):
+
+- `git mv "Space Game/Assets/<Pack>" "Space Game/Assets/ThirdParty/<Pack>"`. Asset GUIDs are unchanged by a move, so scene/prefab references survive — only `.asmdef`/`.asmref` paths, `*.rsp`, and any hard-coded `AssetDatabase` path strings in editor scripts need fix-ups.
+- Add `Assets/ThirdParty/<Pack>/ThirdParty.<Pack>.asmdef`. Delete the pack's demo/example/sample-scene folders in the same PR.
+- `dotnet build` the three csproj + run `tools\Run-UnityTests.ps1 -TestPlatform All`. Repo size is unchanged here (history still holds the blobs) but the tree is policy-compliant and future branches stay clean.
+
+### 17d. Optional coordinated history purge (DESTRUCTIVE — gated, not unilateral)
+
+Only to reclaim `.git`/LFS size, and only for packs classified **drop** in 17b. Hard gate, all must hold before running:
+
+1. The friend has **no open feature branch** (coordinate a window).
+2. A full mirror backup exists (`git clone --mirror` pushed somewhere off-box) and the change is announced.
+3. Every collaborator will re-clone fresh afterward (rebasing existing local work onto the rewritten history is not supported).
+
+Then `git filter-repo --path <droppedpath> --invert-paths` (plus the matching LFS objects) on a mirror, validate, force-push, everyone re-clones. This is the only step that rewrites shared history; never do it as a side effect of another task.
+
+### 17e. Salvage the friend's real code onto fresh branches (depends on 17c)
+
+Per D-013, recover the gameplay code from the divergent branches without the vendor noise. Smallest first to prove the pattern:
+
+1. `procedural-world-generation-tier-4-test` — 36 own-code files / 3.8K lines (planet terrain, ice planet, blood VFX hookup, test worlds).
+2. `interior-variety` — 62 files / 8.7K lines (subset of below).
+3. `interiors-changes` — 73 files / 14.3K lines (superset; full Interiors + Blueprints).
+
+For each: branch off fresh `main`, bring over only `Space Game/Assets/Scripts/**` and genuine `.asset` content (not vendor dirs — those are now satisfied by the relocated `Assets/ThirdParty/` packs), resolve against current `main` (Interiors already partly landed via PR #24, so expect overlap), rebase, PR. `merge/all-branches-to-main` (0 conflicts vs `main`, 29 ahead) is the reference for what is already integrated — diff against it to avoid re-doing landed work.
+
+Key files / branches:
+- `origin/merge/all-branches-to-main` — clean integration reference.
+- `origin/procedural-world-generation-tier-4-test`, `origin/interior-variety`, `origin/interiors-changes` — salvage sources.
+- Stale post-merge branches to verify-then-delete: `origin/Interiors` (was PR #23), `origin/test-plane-world-2` (was PR #22).

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -251,3 +251,54 @@ Status 2026-05-08: first cleanup slice done. `FriendSlopUI` state/constants move
 Currently no EditMode coverage for: `NetworkSessionManager` (mock-needed), `FriendSlopUI` partials, `PlayerInteractor`, `NetworkFirstPersonController` health/lifecycle/movement, weapons (`LaserGun`, `BoxingGloves`). The seams that already break are well-covered; gameplay surface that *could* break invisibly is not.
 
 Lowest-hanging fruit: `LaserGun` / `BoxingGloves` — they're small, server-authoritative, and have clear pass/fail predicates.
+
+## 16. Interiors merge follow-ups (queued on `tests/interior-coverage`)
+
+Surfaced during the post-merge architectural review in [PR #24](https://github.com/TheSchlote/Friend-Slop/pull/24). All work is queued on the `tests/interior-coverage` branch.
+
+### 16a. Documentation gaps — friends' agents will get bitten
+
+The whole Interiors system is invisible to `CLAUDE.md` and `docs/architecture.md`, the NGO additive-scene spawn contract isn't codified, and `Tools/Friend Slop/Repair Scene Wiring` isn't listed next to the other editor menus. Updates needed:
+
+- **`Space Game/CLAUDE.md`** — bump Unity to `6000.3.15f1`; add hard rule "NGO + additive scenes: set active scene before `Instantiate` + `NetworkObject.Spawn`, never `MoveGameObjectToScene` after spawn — use `ActiveSceneScope`"; add hard rule "filter `NetworkObject.IsSpawned` when calling `FindObjectsByType`" (NGO parks `NetworkPrefabsList` templates in Bootstrap as inactive instances); add `Tools/Repair Scene Wiring` to the builder list; add Interiors subsection to Architecture (BuildingDefinition, RoomDefinition, FurnitureDefinition, InteriorCatalog, BlueprintAsset, InteriorEntrance → InteriorSessionData → InteriorSceneBootstrapper); add `FriendSlop.Interiors` and `FriendSlop.Interiors.Blueprints` to the namespace map; update §5 asmdef from "being split" to current (Core/Foundation, Runtime, UI, Editor).
+- **`docs/architecture.md`** — update D-005 status (ShipInterior + per-planet additive is live), D-006 (split is current), D-007 (5 baselined files listed below). New decisions:
+  - **D-009: Interior generation as data-driven content** (Building/Room/Furniture/Catalog + deterministic-RNG-per-room contract).
+  - **D-010: Blueprints as authored interior layouts** (`BlueprintAsset` + `BlueprintLayoutBuilder`; `ApplyDoorPolicy` is bypassed for blueprints because edge state is user-authored).
+  - **D-011: NGO scene placement contract** — `ActiveSceneScope` pattern + the `IsSpawned` filter for find queries.
+- **`docs/FeatureIntegrationContracts.md`** — add 4 contracts: "New Building Type," "New Furniture Definition," "New Blueprint," "New Networked Spawn." Update PR checklist with `ActiveSceneScope` + `IsSpawned` lines.
+- **New `docs/InteriorSystem.md`** (~80 lines) — single-page pipeline overview: procedural vs. blueprint path, server picks seed / clients regenerate, doors are `NetworkObject`s, furniture is deterministic-but-local. Point to the FeatureIntegrationContracts entries for "how to add X."
+- **New `docs/NetworkObjectSceneOwnership.md`** (~50 lines) — codifies `ActiveSceneScope`, the `IsSpawned` filter, and the gotchas (`NetworkPrefabsList` templates, `MoveGameObjectToScene`-after-Spawn unreliability).
+
+### 16b. Code issues surfaced during the review
+
+- **`PlanetLootSpawner.IsCurrentActivePlanet()`** ([line 142-148](Space%20Game/Assets/Scripts/Loot/PlanetLootSpawner.cs)) returns `true` when `planetEnvironment == null`. Should default to `false` — current behavior silently runs as the active spawner when env config is missing/broken.
+- **`MeteorShower`** ([line 121](Space%20Game/Assets/Scripts/Hazards/MeteorShower.cs)) still uses the old `Instantiate → MoveGameObjectToScene → Spawn` anti-pattern. Convert to `ActiveSceneScope`.
+- **`AnomalySpawner.Spawn()`** ([line 71](Space%20Game/Assets/Scripts/Hazards/AnomalySpawner.cs)) defaults `destroyWithScene=false`, leaking anomalies into `DontDestroyOnLoad` across planet transitions. Verify intent; likely should be `true`.
+- **Dead test code**: `AssertConnectedMenuLayoutDoesNotOverlap` at [FriendSlopPrototypeSmokeTests.cs:490](Space%20Game/Assets/Tests/PlayMode/FriendSlopPrototypeSmokeTests.cs) is defined but never called.
+
+### 16c. Tests to add (priority order)
+
+1. **`BlueprintLayoutBuilderTests`** (EditMode) — `BlueprintLayoutBuilder.Build` currently has zero coverage and is the entire authored-layout pipeline. Pure static function, easy to test. Cover: empty/null blueprint returns empty layout, room placement, socket adjacency, edge-state overrides (Wall/Open/Door), variant picking, per-slot overrides.
+2. **`BuildingDefinitionRoomPoolTests`** (EditMode) — defensive against future `FormerlySerializedAs` renames. The recent `roomPool` → `optionalPool` rename silently broke `InteriorLayoutGeneratorTests`. A direct unit test on `BuildingDefinition.RoomPool` (combines `optionalPool` + `requiredRooms.Definition`) would catch the next one before it bites.
+3. **`PlanetLootSpawnerSceneOwnershipTests`** (PlayMode) — verifies the `ActiveSceneScope` fix on the Tier 2+ scene-owned spawner path that's not currently exercised. Load a Tier 2 scene, start host, assert all spawned loot ends up in the planet scene.
+4. **`FurnitureSelectionTests`** (EditMode) — `HasTagOverlap`, `IsCappedOut`, `PickFurnitureForAnchor`, `OverlapsExisting` in `InteriorSceneBootstrapper.Furniture.cs`. Pure static helpers; easy to test.
+5. **`InteriorSceneBootstrapper` PlayMode smoke** — spawn an interior, teleport a player in, assert rooms + doors present. Currently no coverage.
+6. **`InteriorCatalogTests`** (EditMode) — catalog enumeration / lookup; ensure no null entries ship.
+
+### 16d. Baselined oversized files (split before adding to)
+
+Listed in `ArchitectureGuardrailTests.ExistingOversizedRuntimeFiles`. Split order recommended:
+
+- `Assets/Scripts/Interiors/Blueprints/BlueprintEditorController.cs` — 545 lines, editor-only, smallest, safest first split.
+- `Assets/Scripts/Interiors/InteriorSceneBootstrapper.cs` — 832 lines; natural extraction: wall-patching / garage-door geometry, then materials, then door spawning.
+- `Assets/Scripts/Interiors/InteriorSceneBootstrapper.Furniture.cs` — 527 lines; extract pickers (`PickFurnitureForAnchor`, `HasTagOverlap`, etc.) into `.Furniture.Picking.cs`.
+- `Assets/Scripts/Interiors/Blueprints/BlueprintEditorUI.cs` — 1005 lines; per-panel split.
+- `Assets/Scripts/Interiors/InteriorLayoutGenerator.cs` — 1727 lines; biggest. Natural seams: required-room quotas, frontier expansion, downward-connector mirroring, fallback generation.
+
+After each split: drop the file's entry from `ExistingOversizedRuntimeFiles` if the main file lands under 400.
+
+### 16e. Editor migrations the agent can't run
+
+These need a human in the editor; queued for the next playtest pass.
+
+- Run `Tools/Friend Slop/Repair Scene Wiring` once to delete the stale ship root from `FriendSlopPrototype.unity` (the wiring repair was updated to handle this on its next run). After running, re-enable `ValidateBootstrapDoesNotOwnShipInterior` in `PlanetSceneValidator.TryValidate`.

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -258,16 +258,15 @@ Surfaced during the post-merge architectural review in [PR #24](https://github.c
 
 ### 16a. Documentation gaps — friends' agents will get bitten
 
-The whole Interiors system is invisible to `CLAUDE.md` and `docs/architecture.md`, the NGO additive-scene spawn contract isn't codified, and `Tools/Friend Slop/Repair Scene Wiring` isn't listed next to the other editor menus. Updates needed:
+The whole Interiors system was invisible to `CLAUDE.md` and `docs/architecture.md`, the NGO additive-scene spawn contract wasn't codified, and `Tools/Friend Slop/Repair Scene Wiring` wasn't listed next to the other editor menus.
 
-- **`Space Game/CLAUDE.md`** — bump Unity to `6000.3.15f1`; add hard rule "NGO + additive scenes: set active scene before `Instantiate` + `NetworkObject.Spawn`, never `MoveGameObjectToScene` after spawn — use `ActiveSceneScope`"; add hard rule "filter `NetworkObject.IsSpawned` when calling `FindObjectsByType`" (NGO parks `NetworkPrefabsList` templates in Bootstrap as inactive instances); add `Tools/Repair Scene Wiring` to the builder list; add Interiors subsection to Architecture (BuildingDefinition, RoomDefinition, FurnitureDefinition, InteriorCatalog, BlueprintAsset, InteriorEntrance → InteriorSessionData → InteriorSceneBootstrapper); add `FriendSlop.Interiors` and `FriendSlop.Interiors.Blueprints` to the namespace map; update §5 asmdef from "being split" to current (Core/Foundation, Runtime, UI, Editor).
-- **`docs/architecture.md`** — update D-005 status (ShipInterior + per-planet additive is live), D-006 (split is current), D-007 (5 baselined files listed below). New decisions:
-  - **D-009: Interior generation as data-driven content** (Building/Room/Furniture/Catalog + deterministic-RNG-per-room contract).
-  - **D-010: Blueprints as authored interior layouts** (`BlueprintAsset` + `BlueprintLayoutBuilder`; `ApplyDoorPolicy` is bypassed for blueprints because edge state is user-authored).
-  - **D-011: NGO scene placement contract** — `ActiveSceneScope` pattern + the `IsSpawned` filter for find queries.
-- **`docs/FeatureIntegrationContracts.md`** — add 4 contracts: "New Building Type," "New Furniture Definition," "New Blueprint," "New Networked Spawn." Update PR checklist with `ActiveSceneScope` + `IsSpawned` lines.
-- **New `docs/InteriorSystem.md`** (~80 lines) — single-page pipeline overview: procedural vs. blueprint path, server picks seed / clients regenerate, doors are `NetworkObject`s, furniture is deterministic-but-local. Point to the FeatureIntegrationContracts entries for "how to add X."
-- **New `docs/NetworkObjectSceneOwnership.md`** (~50 lines) — codifies `ActiveSceneScope`, the `IsSpawned` filter, and the gotchas (`NetworkPrefabsList` templates, `MoveGameObjectToScene`-after-Spawn unreliability).
+**Status 2026-05-13: landed.** All 16a items shipped as a single doc PR on this branch.
+
+- **`Space Game/CLAUDE.md`** — Unity bumped to `6000.3.15f1`; new hard rule 9 covers the NGO active-scene-before-Spawn contract and the `IsSpawned` filter; `Tools/Repair Scene Wiring` added under rule 2; Interiors subsection added to Architecture; `FriendSlop.Interiors` + `FriendSlop.Interiors.Blueprints` added to the namespace map; rule 5 asmdef wording updated to current state (Core/Foundation, Runtime, UI, Editor).
+- **`docs/architecture.md`** — D-005 / D-006 / D-007 status updates and added decisions: **D-009** (interior generation as data-driven content), **D-010** (blueprints as authored interior layouts), **D-011** (NGO scene placement contract). Anti-patterns section gained `MoveGameObjectToScene`-after-Spawn, `destroyWithScene:false` defaulting, and unfiltered `FindObjectsByType` over NGO types.
+- **`docs/FeatureIntegrationContracts.md`** — 4 new contracts: "New Networked Spawn," "New Building Type," "New Furniture Definition," "New Blueprint." PR checklist gained `ActiveSceneScope` + `IsSpawned` lines.
+- **New `docs/InteriorSystem.md`** — full pipeline overview, procedural vs. blueprint path, networked-vs-local table, known oversized files.
+- **New `docs/NetworkObjectSceneOwnership.md`** — codifies the active-scene-before-Spawn pattern, the `IsSpawned` filter, despawn-before-unload, and the known stale sites (`MeteorShower`, `AnomalySpawner`) queued in 16b.
 
 ### 16b. Code issues surfaced during the review
 

--- a/Space Game/Assets/ThirdParty.meta
+++ b/Space Game/Assets/ThirdParty.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6dfb9883efb83434adce12dc269b2889
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Space Game/Assets/ThirdParty/README.md
+++ b/Space Game/Assets/ThirdParty/README.md
@@ -1,0 +1,22 @@
+# Assets/ThirdParty — vendor quarantine
+
+Every Asset Store / third-party pack lives here, one folder per pack, **not** in
+`Assets/<PackName>/`.
+
+Rules (full rationale: [`docs/architecture.md`](../../../docs/architecture.md) **D-012 / D-013**,
+agent summary: [`Space Game/CLAUDE.md`](../../CLAUDE.md) hard rule 10):
+
+1. **Import-once.** A pack is added in a single dedicated PR (`vendor: add <Pack> vX`)
+   that does nothing else. Feature branches never import, re-import, or re-export a
+   pack — they only reference one that already landed on `main`.
+2. **One folder, own asmdef.** `Assets/ThirdParty/<Pack>/` with a
+   `ThirdParty.<Pack>.asmdef` (set `autoReferenced` only when our runtime calls into
+   it). This stops our code coupling to the pack's churn.
+3. **Strip the fat.** Delete the pack's demo / example / sample-scene folders on
+   import.
+4. **Binaries via LFS.** If the pack adds a new binary extension, extend
+   `.gitattributes` LFS coverage in the same import PR.
+
+Migration of the packs currently mislocated on `main` (`HIVEMIND`,
+`LowPolyInterior`, `LowPolyInterior2`, `Plugins/Microdetail`,
+`YughuesFreeRockMaterials`, `_Recovery`) is staged in **BACKLOG §17**.

--- a/Space Game/Assets/ThirdParty/README.md.meta
+++ b/Space Game/Assets/ThirdParty/README.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: a52811d9784559cc6bb6966cc9ae5c51
+TextScriptImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Space Game/CLAUDE.md
+++ b/Space Game/CLAUDE.md
@@ -8,13 +8,13 @@ If a task seems to require the editor (visual layout, dragging references, bakin
 
 ## Project Overview
 
-**Friend Slop Retrieval** is a cooperative multiplayer prototype built on Unity 6 (`6000.3.4f1`). Players board a ship, fly to a small spherical planet, scavenge salvage and three rocket parts, dodge roaming monsters, and escape together via the launchpad. Multi-planet progression is in flight.
+**Friend Slop Retrieval** is a cooperative multiplayer prototype built on Unity 6 (`6000.3.15f1`). Players board a ship, fly to a small spherical planet, scavenge salvage and three rocket parts, dodge roaming monsters, and escape together via the launchpad. Multi-planet progression is in flight.
 
 Stack: Netcode for GameObjects, Unity Transport, Unity Relay/Lobbies/Auth, Universal Render Pipeline, Input System, UGUI.
 
 ## Build & Run
 
-- **Engine**: Unity 6000.3.4f1 (the workflow `validate-unity-version` job enforces this).
+- **Engine**: Unity 6000.3.15f1 (the workflow `validate-unity-version` job enforces this).
 - **Local C# compile checks** (no editor required):
   ```powershell
   dotnet build 'Space Game\FriendSlop.Runtime.csproj'        /p:GenerateMSBuildEditorConfigFile=false
@@ -44,9 +44,10 @@ When adding gameplay content, the order of preference is: new ScriptableObject `
 
 ### 2. Builders: Repair before Rebuild
 
-There are two editor menu paths:
+There are three editor menu paths:
 
 - **`Tools/Friend Slop/Repair Prototype Scene`** — idempotent. Loads existing prefabs/materials/assets and only creates what's missing. **This is the safe default.** Use it whenever you need to ensure scene/prefab consistency.
+- **`Tools/Friend Slop/Repair Scene Wiring`** — idempotent fix-ups for the additive-scene split: keeps `MainGameSceneCatalog`, `PlanetDefinition.planetScene`, Build Settings, and the bootstrap-vs-`ShipInterior` ownership in agreement. Run when scene assets, planet assets, or the catalog drift. Implementation: [`Editor/FriendSlopSceneWiringRepair.cs`](Assets/Scripts/Editor/FriendSlopSceneWiringRepair.cs).
 - **`Tools/Friend Slop/Rebuild Prototype Scene`** — destructive. Recreates every prefab and the scene from scratch. Top-level asset GUIDs are preserved (so `NetworkPrefabsList` survives), but every sub-object FileID inside prefabs/scenes regenerates, producing a giant YAML diff and silently breaking any sub-object reference. **Do not run this without explicit human request.**
 
 When asked to add a new prefab type, extend the *Repair* path so it's load-or-create, not always-create.
@@ -69,18 +70,18 @@ All gameplay state lives on the server.
 
 ### 5. Module boundaries (asmdefs)
 
-The project is being split into asmdefs to enforce dependency direction. Once the split lands, the rule is:
+Current runtime assemblies, in dependency order:
 
 ```
-Core  <-  Gameplay  <-  UI  <-  Bootstrap (editor builders, scene/prefab generation)
-                  ^
-                  |
-              Networking
+FriendSlop.Core  <-  FriendSlop.Runtime  <-  FriendSlop.UI  <-  FriendSlop.Editor (editor-only)
 ```
 
-`Core` contains pure data + utilities and has no Unity dependency where possible. `UI` may read from `Gameplay` but never the reverse. `Editor`-only code never compiles into runtime assemblies.
+- `FriendSlop.Core` (`Scripts/Core/Foundation/`) — pure data + utilities, no Netcode dependency. The D-006 foundation slice.
+- `FriendSlop.Runtime` (`Scripts/`) — everything else runtime: networking, gameplay, scene management, hazards, interiors. The remaining D-006 split (carving Networking and Gameplay out of Runtime) is queued.
+- `FriendSlop.UI` (`Scripts/UI/`) — may read from `Runtime` but never the reverse.
+- `FriendSlop.Editor` (`Scripts/Editor/`) — editor-only builders, validators, repair tools. Never referenced by a runtime assembly.
 
-If you need a reference that crosses an arrow the wrong direction, the design is wrong; raise it instead of forcing it.
+If you need a reference that crosses an arrow the wrong direction, the design is wrong; raise it instead of forcing it. `ArchitectureGuardrailTests` enforces no wrong-way UI/Editor references at CI.
 
 ### 6. Size and complexity ceilings
 
@@ -103,6 +104,15 @@ When in doubt, content is data, not code. Adding a new planet, new loot variant,
 1. New `.asset` file (a ScriptableObject instance).
 2. Wired into the appropriate catalog (`PlanetCatalog`, future `LootCatalog`, etc.).
 3. **Not** a new branch in a builder method.
+
+### 9. NGO + additive scenes: set active scene *before* `Spawn`
+
+Friend Slop runs with `NetworkConfig.EnableSceneManagement = true` and loads `ShipInterior` + `Planet_*` scenes additively. Two gotchas are load-bearing and have already cost real debugging time:
+
+- **Spawn placement.** `NetworkObject.Spawn(destroyWithScene: true)` latches `SceneOriginHandle` to the GameObject's scene at the moment of spawn. **Set the active scene before `Instantiate` + `Spawn`** so the clone lands in the target scene from the start. Do **not** rely on `SceneManager.MoveGameObjectToScene` after `Spawn` — NGO scene management fights post-Spawn moves and they silently fail to stick. The canonical pattern is an active-scene swap around the whole spawn batch; see [`PrototypeNetworkBootstrapper.Spawning.cs`](Assets/Scripts/Networking/PrototypeNetworkBootstrapper.Spawning.cs) (`ActiveSceneScope`) and [`PlanetLootSpawner.TrySpawnNow`](Assets/Scripts/Loot/PlanetLootSpawner.cs) for reference implementations. Always pass `destroyWithScene: true` unless the object genuinely should outlive its scene (the default `false` sends it to `DontDestroyOnLoad`, which is almost never what you want).
+- **`FindObjectsByType` filter.** With NGO scene management on, the `NetworkPrefabsList` parks prefab *templates* in the Bootstrap scene as inactive `NetworkObject` instances. `Object.FindObjectsByType<T>(FindObjectsInactive.Include, ...)` returns them alongside live runtime clones. Filter on `NetworkObject.IsSpawned` (or `GetComponent<NetworkObject>()?.IsSpawned == true`) when the test or runtime code cares about live game state. Reference: `CountSpawned<T>` in [`FriendSlopPrototypeSmokeTests.cs`](Assets/Tests/PlayMode/FriendSlopPrototypeSmokeTests.cs).
+
+Full rationale and additional pitfalls: [docs/NetworkObjectSceneOwnership.md](../docs/NetworkObjectSceneOwnership.md).
 
 ## Architecture (current)
 
@@ -141,11 +151,31 @@ Win/lose evaluation lives in **`RoundObjective`** ScriptableObject subclasses (`
 - `PlanetEnvironment` — owns the launchpad, spawn points, and asset snap on `OnEnable`.
 - `PlanetSurfaceAnchor` — opt-in marker for "snap me to the surface."
 
+### Interiors
+
+Buildings on planets open into their own additively loaded interior scene. The content is data-driven and the layout is deterministic per seed.
+
+- **Data definitions** (ScriptableObjects):
+  - `BuildingDefinition` — room counts, floor counts, required-room list, optional room pool, special-room targets.
+  - `RoomDefinition` — cell footprint, floor restrictions, furniture rules, room kind/category.
+  - `FurnitureDefinition` — anchor placement, tags, footprint, prefab, weight, interactable flag.
+  - `BlueprintAsset` — authored layout: explicit room placements + per-edge wall/open/door overrides. Bypasses the procedural generator.
+  - `InteriorCatalog` — registry that ships all `BuildingDefinition`s and `FurnitureDefinition`s.
+- **Entry / handoff:**
+  - `InteriorEntrance` (exterior door, `NetworkBehaviour`) writes `InteriorSessionData` (seed, definition, return pose, requesting client, scene path, optional blueprint) and asks the server to load the interior scene.
+  - `InteriorSceneBootstrapper` runs in the loaded interior scene, reads `InteriorSessionData`, and replicates seed/origin to clients.
+- **Two generation paths** (both produce an `InteriorLayout`):
+  - Procedural — `InteriorLayoutGenerator.Generate(definition, seed)`: pure, deterministic, all clients regenerate locally.
+  - Authored — `BlueprintLayoutBuilder.Build(blueprint, definition)`: skips the procedural door-policy pass because edge state is user-authored.
+- **What is networked vs. local:** doors (`InteriorDoor`, `InteriorExitDoor`) are spawned as `NetworkObject`s so open/close state syncs across clients. Furniture is deterministic-but-local — every client picks the same pieces from the seed, no `NetworkObject` per chair.
+
+When adding interior content, prefer a new `.asset` (Building/Room/Furniture/Blueprint) over a code branch. See [docs/InteriorSystem.md](../docs/InteriorSystem.md) for the full pipeline and [docs/FeatureIntegrationContracts.md](../docs/FeatureIntegrationContracts.md) for the "New Building Type / New Furniture / New Blueprint" contracts.
+
 ## Namespace map
 
 | Namespace | Location |
 |---|---|
-| `FriendSlop.Core` | `Scripts/Core/` |
+| `FriendSlop.Core` | `Scripts/Core/Foundation/` (its own asmdef) |
 | `FriendSlop.Networking` | `Scripts/Networking/` |
 | `FriendSlop.SceneManagement` | `Scripts/SceneManagement/` |
 | `FriendSlop.Player` | `Scripts/Player/` |
@@ -154,6 +184,8 @@ Win/lose evaluation lives in **`RoundObjective`** ScriptableObject subclasses (`
 | `FriendSlop.Hazards` | `Scripts/Hazards/` |
 | `FriendSlop.Effects` | `Scripts/Effects/` |
 | `FriendSlop.Ship` | `Scripts/Ship/` |
+| `FriendSlop.Interiors` | `Scripts/Interiors/` |
+| `FriendSlop.Interiors.Blueprints` | `Scripts/Interiors/Blueprints/` |
 | `FriendSlop.UI` | `Scripts/UI/` |
 | `FriendSlop.Interaction` | `Scripts/Interaction/` |
 | `FriendSlop.Editor` | `Scripts/Editor/` (editor-only) |
@@ -175,6 +207,8 @@ Read these before making non-trivial changes:
 - [docs/FeatureIntegrationContracts.md](../docs/FeatureIntegrationContracts.md) — extension points and PR contracts for agents adding features.
 - [docs/SingletonAudit.md](../docs/SingletonAudit.md) — current singleton audit and migration plan.
 - [docs/SpaceshipSceneManagement.md](../docs/SpaceshipSceneManagement.md) — current scene state, target additive multi-scene layout, scene-ownership rules.
+- [docs/NetworkObjectSceneOwnership.md](../docs/NetworkObjectSceneOwnership.md) — NGO + additive-scene spawn contract. Read before spawning a `NetworkObject` into any scene other than the caller's.
+- [docs/InteriorSystem.md](../docs/InteriorSystem.md) — interior generation pipeline (data → entrance → bootstrapper → procedural/blueprint).
 - [docs/RemainingFeatures.md](../docs/RemainingFeatures.md) — feature backlog. Check before claiming a feature is "missing"; it may already be tracked.
 - [docs/builder-audit.md](../docs/builder-audit.md) — GUID-determinism analysis of the editor builders. Read this before editing anything in `Assets/Scripts/Editor/`.
 - [docs/MultiplayerQA.md](../docs/MultiplayerQA.md) — manual QA checklist for human playtests.

--- a/Space Game/CLAUDE.md
+++ b/Space Game/CLAUDE.md
@@ -114,6 +114,16 @@ Friend Slop runs with `NetworkConfig.EnableSceneManagement = true` and loads `Sh
 
 Full rationale and additional pitfalls: [docs/NetworkObjectSceneOwnership.md](../docs/NetworkObjectSceneOwnership.md).
 
+### 10. Third-party assets & branch hygiene
+
+The repo's scalability bottleneck is vendor-pack churn, not the game code. Hold the line:
+
+- **New Asset Store / third-party pack → `Assets/ThirdParty/<Pack>/`** (or an embedded `Packages/` package), with its own `ThirdParty.<Pack>` asmdef, in a **dedicated import-only PR**. Never `Assets/<Pack>/`. Never bundle a pack import with feature code. Never re-import or re-export an existing pack on a feature branch. Strip demo/example/sample-scene folders on import; add LFS coverage to `.gitattributes` for any new binary extension in that same PR.
+- **Feature branches are short-lived and rebased on `main`; one feature per branch.** If a feature needs a new pack, the pack PR lands first; the feature branch then only references it.
+- Packs currently mislocated on `main` (`HIVEMIND`, `LowPolyInterior`, `LowPolyInterior2`, `Plugins/Microdetail`, `YughuesFreeRockMaterials`, `_Recovery`) are being relocated per **BACKLOG §17** — do not add to them or re-import them meanwhile.
+
+Full rationale: [docs/architecture.md](../docs/architecture.md) D-012 / D-013.
+
 ## Architecture (current)
 
 ### Round lifecycle

--- a/docs/FeatureIntegrationContracts.md
+++ b/docs/FeatureIntegrationContracts.md
@@ -127,6 +127,29 @@ Tests:
 - EditMode tests for validation helpers.
 - PlayMode tests for multi-client authority-sensitive behavior when feasible.
 
+## New Networked Spawn
+
+Use this for any code that creates a `NetworkObject` at runtime: loot, monsters, doors, hazards, blueprints, interior content, future projectiles. Read [NetworkObjectSceneOwnership.md](NetworkObjectSceneOwnership.md) first; this contract is the short version.
+
+Expected path:
+
+- Spawn on the server only (`if (!IsServer) return;`).
+- If the target scene is not the caller's current active scene, swap the active scene around the whole batch before `Instantiate` so `NetworkObject.Spawn(destroyWithScene: true)` captures the right `SceneOriginHandle`. Reference implementations: `ActiveSceneScope` in `PrototypeNetworkBootstrapper.Spawning.cs`; the inlined try/finally in `PlanetLootSpawner.TrySpawnNow`.
+- Pass `destroyWithScene: true` unless the object genuinely outlives its scene (`false` puts it in `DontDestroyOnLoad`, which is almost never the right answer for planet/interior content).
+- Despawn on the server with `NetworkObject.Despawn(destroy: true)` when the owning scene unloads or the round transitions.
+
+Do not:
+
+- Call `SceneManager.MoveGameObjectToScene` after `NetworkObject.Spawn`. NGO scene management fights post-Spawn moves with `EnableSceneManagement = true`.
+- `Instantiate`/`Destroy` a networked prefab directly.
+- Trust client-provided spawn positions or counts.
+- Call `Object.FindObjectsByType<T>` over an NGO type without filtering by `NetworkObject.IsSpawned` when you care about live runtime state. NGO parks `NetworkPrefabsList` templates as inactive instances in the Bootstrap scene.
+
+Tests:
+
+- PlayMode assertion that the spawned objects land in the intended scene (`gameObject.scene == expected`).
+- Use `CountSpawned<T>` (see `FriendSlopPrototypeSmokeTests.cs`) for spawn-count assertions; raw `FindObjectsByType` counts will include prefab templates.
+
 ## New Ship Station
 
 Use this for pilot controls, holographic board flows, customization bench, storage, or utilities.
@@ -148,10 +171,74 @@ Tests:
 - EditMode tests for claim/release or station-flow state.
 - PlayMode tests for networked station behavior.
 
+## New Building Type
+
+Use this for a new procedural interior (warehouse, lab, hangar, etc.) that should be rolled, not hand-authored. Read [InteriorSystem.md](InteriorSystem.md) for the full pipeline.
+
+Expected path:
+
+- Add a new `BuildingDefinition` asset under `Assets/Interiors/Buildings/`. Configure room counts, floor counts, required rooms, optional room pool, special-room targets.
+- Register it in the `InteriorCatalog` your `InteriorEntrance` points at.
+- If new room shapes are needed, add `RoomDefinition` assets (see "New Furniture Definition" below for the related furniture path).
+- Make sure all generation inputs are functions of the seed. No `Time.time`, no `Random.Range` without going through the seeded RNG, no order dependence on `FindObjectsByType`. The determinism contract is in D-009.
+
+Do not:
+
+- Branch in `InteriorLayoutGenerator` on building name.
+- Hand-edit interior scene YAML.
+- Introduce per-furniture `NetworkObject`s — furniture is deterministic-but-local.
+
+Tests:
+
+- EditMode test that `BuildingDefinition.RoomPool` returns the expected set (combines `optionalPool` + `requiredRooms.Definition`). This catches future `FormerlySerializedAs` renames before they ship.
+- EditMode generator test if the new building introduces a new constraint shape.
+
+## New Furniture Definition
+
+Use this for adding furniture variety to existing room types.
+
+Expected path:
+
+- Add a new `FurnitureDefinition` asset. Configure anchor placement (`Wall` / `Corner` / `Center` / `Tabletop` / `AroundTable` / `WallHanging`), tags, footprint, prefab, weight, interactable flag.
+- Add it to the relevant `RoomDefinition.furnitureRules` or tag bucket so the picker (`PickFurnitureForAnchor`) sees it.
+- Make sure footprint and anchor placement match the prefab; the placer relies on the metadata, not the visual.
+
+Do not:
+
+- Spawn the furniture as a `NetworkObject` for cosmetic-only pieces.
+- Bypass `FurnitureAnchor` and place the piece by world position; anchor selection is part of the determinism contract.
+- Modify `InteriorSceneBootstrapper.Furniture.cs` to add a per-piece special case.
+
+Tests:
+
+- EditMode test against the picker helpers (`HasTagOverlap`, `IsCappedOut`, `PickFurnitureForAnchor`, `OverlapsExisting` in `InteriorSceneBootstrapper.Furniture.cs`) when the new piece exercises a tag or cap edge case.
+
+## New Blueprint
+
+Use this for a hand-authored interior (homebase, signature building) where the design wants explicit room placement instead of procedural generation.
+
+Expected path:
+
+- Open the blueprint editor in a playtest (`F1` toggle in the blueprint test scene). Author rooms, edge overrides (`Wall` / `Open` / `Door`), and per-slot variant choices.
+- Save the result as a `BlueprintAsset` under `Assets/Interiors/Blueprints/`.
+- Wire a `BlueprintEntrance` (instead of `InteriorEntrance`) at the building's exterior, pointing at the blueprint.
+- The runtime path is `BlueprintLayoutBuilder.Build(blueprint, definition)` → same `InteriorLayout` shape as procedural → same bootstrapper.
+
+Do not:
+
+- Add procedural fallback logic to the blueprint path. `ApplyDoorPolicy` is intentionally bypassed because edge state is user-authored.
+- Mix blueprint + procedural in the same building. Pick one entry point.
+
+Tests:
+
+- EditMode `BlueprintLayoutBuilderTests`: empty/null blueprint returns empty layout, room placement, socket adjacency, edge-state overrides, variant picking, per-slot overrides.
+
 ## PR Checklist For Feature Agents
 
 - No new `Instance` or `LocalPlayer` static global unless the owner explicitly approved an architecture change.
 - No `FindObjectsByType`, `FindFirstObjectByType`, or `FindObjectOfType` inside `Update`, `FixedUpdate`, or `LateUpdate`.
+- Any `FindObjectsByType<T>` over an NGO type filters by `NetworkObject.IsSpawned` (or uses `CountSpawned<T>`) when it cares about live game state.
+- Any code that spawns a `NetworkObject` into a non-caller scene uses an active-scene swap around `Instantiate` + `Spawn`; no `MoveGameObjectToScene` after `Spawn`. `destroyWithScene: true` unless the object genuinely outlives its scene.
 - No runtime file grows past 400 lines; existing oversized files must not grow.
 - No runtime assembly reference to UI or Editor.
 - New gameplay logic has a test.

--- a/docs/InteriorSystem.md
+++ b/docs/InteriorSystem.md
@@ -1,0 +1,103 @@
+# Interior System
+
+Buildings on planets open into their own additively loaded interior scene. The content is data-driven and the layout is deterministic per seed. There are two generation paths: **procedural** (rolled from a `BuildingDefinition` + seed) and **authored** (driven by a `BlueprintAsset`). Both produce the same `InteriorLayout` shape, so the bootstrapper, door spawner, and furniture pipeline don't fork.
+
+This document is the long form of architecture decisions [D-009](architecture.md) (data-driven interiors) and [D-010](architecture.md) (blueprints). Use it before adding a new building, room, furniture piece, or blueprint.
+
+## Pipeline overview
+
+```
+[planet scene]                                    [interior scene]
+                                                              
+  InteriorEntrance ──writes──▶ InteriorSessionData ──read──▶ InteriorSceneBootstrapper
+   (NetworkBehaviour)             (static carrier)             (NetworkBehaviour)
+                                                                       
+                                                                       ▼
+                                                  ┌────────── procedural ──────────┐
+                                                  │  InteriorLayoutGenerator       │
+                                                  │  .Generate(definition, seed)   │
+                                                  └────────────────────────────────┘
+                                                                  OR
+                                                  ┌────────── authored ────────────┐
+                                                  │  BlueprintLayoutBuilder        │
+                                                  │  .Build(blueprint, definition) │
+                                                  └────────────────────────────────┘
+                                                                       │
+                                                                       ▼
+                                                              InteriorLayout
+                                                              (rooms + connections)
+                                                                       │
+                                                                       ▼
+                                                  spawn rooms, doors, furniture
+```
+
+1. **Player enters the trigger** on `InteriorEntrance` (or `BlueprintEntrance`) attached to the building exterior.
+2. **Server captures session data**: seed (random for procedural; ignored for blueprints), `BuildingDefinition`, return pose, requesting client ID, interior scene path, optional `BlueprintAsset`. This is written to the static `InteriorSessionData`.
+3. **Server loads the interior scene** additively through `NetworkSceneTransitionService`.
+4. **`InteriorSceneBootstrapper.OnNetworkSpawn`** reads `InteriorSessionData` and replicates seed/origin to clients via `NetworkVariable`s.
+5. **All clients** run the layout pipeline locally. Procedural goes through `InteriorLayoutGenerator`; blueprints go through `BlueprintLayoutBuilder`. Both return an `InteriorLayout` (placed rooms + connections).
+6. **The bootstrapper spawns rooms** by instantiating per-room prefabs. For blueprints, `BlueprintLayoutBuilder` resolves each authored slot to a family of variants via `RoomVariants.FindVariants` (room defs whose asset name shares a family — `Room_Residential_Bathroom_2x2.A` and `.B` belong to family `Room_Residential_Bathroom_2x2`) and picks one at spawn time, giving spawn-to-spawn variety without re-rolling the layout.
+7. **Server spawns doors** as `NetworkObject`s so open/close state syncs.
+8. **Each client picks furniture** from the seed locally. Pieces are deterministic — same seed yields same furniture on every client — but they are *not* `NetworkObject`s.
+9. **Players are teleported** into the interior; the exit door (`InteriorExitDoor`) carries the return pose back to the planet.
+
+## Data definitions (ScriptableObjects)
+
+| Asset | Purpose | Location |
+|---|---|---|
+| `BuildingDefinition` | Min/max rooms, floor count, required-room list, optional room pool, special-room targets. | `Assets/Interiors/Buildings/*.asset` |
+| `RoomDefinition` | Cell footprint, floor restrictions, furniture rules, room kind/category, socket directions. | `Assets/Interiors/Rooms/*.asset` |
+| `FurnitureDefinition` | Anchor placement (`Wall`/`Corner`/`Center`/`Tabletop`/`AroundTable`/`WallHanging`), tags, footprint, weight, interactable flag, prefab. | `Assets/Interiors/Furniture/*.asset` |
+| `BlueprintAsset` | Authored layout: explicit room placements + per-edge wall/open/door overrides + per-slot variant overrides. | `Assets/Interiors/Blueprints/*.asset` |
+| `InteriorCatalog` | Registry of all `BuildingDefinition`s and `FurnitureDefinition`s; the runtime lookup surface. | `Assets/Interiors/InteriorCatalog.asset` |
+
+Adding content is a `.asset` file, not a code branch. See the "New Building Type", "New Furniture Definition", and "New Blueprint" entries in [FeatureIntegrationContracts.md](FeatureIntegrationContracts.md).
+
+## What is networked vs. local
+
+| Thing | Where | Why |
+|---|---|---|
+| Seed + building identifier + origin | `NetworkVariable` on `InteriorSceneBootstrapper` | Clients need them to reproduce the layout. |
+| Layout (room placements, connections) | Regenerated locally on each client from the seed | Determinism contract; cheaper than syncing the graph. |
+| Doors (`InteriorDoor`, `InteriorExitDoor`) | Spawned as `NetworkObject`s on the server | Open/close state must sync across clients. |
+| Furniture | Local GameObjects on each client | Deterministic-from-seed; no `NetworkObject` per chair (bandwidth/spawn-count savings). |
+| Blueprint asset reference | Carried by `InteriorSessionData`; clients load the same `BlueprintAsset` by reference | Asset is content, not state. |
+
+**The determinism contract is load-bearing.** Any source of nondeterminism in generation — `Time.time`, an `unseeded Random`, an order-dependent `FindObjectsByType` — is a correctness bug, not a style nit. Clients will see different rooms and the bug will not surface until two players are in the same interior trying to walk through walls.
+
+## Procedural vs. blueprint
+
+| Concern | Procedural | Blueprint |
+|---|---|---|
+| Entry component | `InteriorEntrance` | `BlueprintEntrance` |
+| Seeded? | Yes — server picks, clients regenerate | No — layout is explicit |
+| Door policy pass (`ApplyDoorPolicy`) | Runs | **Bypassed** — edge state is user-authored |
+| Room variants | Generator picks from `BuildingDefinition.RoomPool` per slot | `BlueprintLayoutBuilder` resolves family + grid size via `RoomVariants.FindVariants` and rolls per spawn |
+| When to use | Generic dungeons, warehouses, randomised buildings | Hand-authored signature buildings (residential, homebase) |
+| Authoring tool | None — content is the `BuildingDefinition` + room pool | `BlueprintEditorController` / `BlueprintEditorUI` (F1 toggle in test scenes) |
+
+Don't mix the two in a single building. Pick one entry component.
+
+## Where the code lives
+
+- `Space Game/Assets/Scripts/Interiors/` — runtime data, entrance, exit, bootstrapper, generator, doors, minimap, events.
+- `Space Game/Assets/Scripts/Interiors/Blueprints/` — blueprint asset, builder, entrance variant, editor controller/UI, room variant helpers.
+- `Space Game/Assets/Scripts/Editor/Builders/FriendSlopSceneBuilder.Interiors*.cs` — editor-time prefab/scene generation for interior content.
+- `Space Game/Assets/Tests/EditMode/Editor/InteriorLayoutGeneratorTests.cs` — current EditMode coverage. More tests queued in [BACKLOG.md](../BACKLOG.md) section 16c (`BlueprintLayoutBuilderTests`, `BuildingDefinitionRoomPoolTests`, `FurnitureSelectionTests`, `InteriorCatalogTests`, plus a PlayMode smoke).
+
+## Known oversized files
+
+The following are baselined in `ArchitectureGuardrailTests.ExistingOversizedRuntimeFiles` and **must be split before adding to**:
+
+- `InteriorLayoutGenerator.cs` (1727 lines) — split at: required-room quotas, frontier expansion, downward-connector mirroring, fallback generation.
+- `BlueprintEditorUI.cs` (1005 lines, editor-only) — per-panel split.
+- `InteriorSceneBootstrapper.cs` (832 lines) — extract wall-patching / garage-door geometry, then materials, then door spawning.
+- `BlueprintEditorController.cs` (545 lines, editor-only) — smallest, safest first split.
+- `InteriorSceneBootstrapper.Furniture.cs` (527 lines) — extract pickers (`PickFurnitureForAnchor`, `HasTagOverlap`) into `.Furniture.Picking.cs`.
+
+## Related
+
+- [Space Game/CLAUDE.md](../Space%20Game/CLAUDE.md) — agent-facing hard rules, including the Interiors subsection.
+- [architecture.md](architecture.md) — decisions D-009 (data-driven content) and D-010 (blueprints).
+- [NetworkObjectSceneOwnership.md](NetworkObjectSceneOwnership.md) — D-011, which governs how doors and any other interior `NetworkObject`s get spawned.
+- [FeatureIntegrationContracts.md](FeatureIntegrationContracts.md) — the "New Building Type", "New Furniture Definition", and "New Blueprint" contracts.

--- a/docs/NetworkObjectSceneOwnership.md
+++ b/docs/NetworkObjectSceneOwnership.md
@@ -1,0 +1,76 @@
+# NetworkObject Scene Ownership
+
+Friend Slop runs Netcode for GameObjects (NGO) with `NetworkConfig.EnableSceneManagement = true` and loads `ShipInterior` + `Planet_*` + interior scenes **additively**. That choice forces a small set of contracts on every piece of runtime code that spawns or queries `NetworkObject`s. Get these wrong and the symptoms are silent: objects end up in `DontDestroyOnLoad`, spawn counts assert before any real spawn fires, post-Spawn scene moves "succeed" and then revert. Each pitfall below has already cost real debugging time.
+
+This document is the long form of CLAUDE.md hard rule 9 and architecture decision D-011. Read it before writing new spawn code or new tests that count network objects.
+
+## Rule 1 — Set the active scene *before* `Instantiate` + `Spawn`
+
+`NetworkObject.Spawn(destroyWithScene: true)` latches `SceneOriginHandle` to whatever scene the GameObject is in **at the moment of `Spawn`**. The way to put a clone in `targetScene` is to make `targetScene` active before `Instantiate`. Don't `Instantiate` first and `MoveGameObjectToScene` afterwards — with NGO scene management on, the move fights NGO and silently fails to stick.
+
+The canonical pattern is an active-scene swap around the whole spawn batch:
+
+```csharp
+// PrototypeNetworkBootstrapper.Spawning.cs — private ref struct ActiveSceneScope.
+using (new ActiveSceneScope(activeEnv.gameObject.scene))
+{
+    foreach (var spawnPoint in anchors)
+    {
+        var clone = Instantiate(prefab, spawnPoint.position, spawnPoint.rotation);
+        clone.NetworkObject.Spawn(destroyWithScene: true);
+    }
+}
+```
+
+`ActiveSceneScope` is a private nested `ref struct` in [`PrototypeNetworkBootstrapper.Spawning.cs`](../Space%20Game/Assets/Scripts/Networking/PrototypeNetworkBootstrapper.Spawning.cs). The same pattern is inlined in [`PlanetLootSpawner.TrySpawnNow`](../Space%20Game/Assets/Scripts/Loot/PlanetLootSpawner.cs) as a `try`/`finally` (it would be reasonable to hoist `ActiveSceneScope` into a shared utility once a third call site appears — don't promote it for a single duplication).
+
+Pass `destroyWithScene: true` unless the object genuinely needs to outlive its owning scene. The default of `false` sends the object to `DontDestroyOnLoad`, which is almost never the right answer for planet/interior content and leaks across planet transitions.
+
+## Rule 2 — Filter `IsSpawned` on `FindObjectsByType<T>`
+
+With NGO scene management on, `NetworkManager.NetworkConfig.NetworkPrefabsList` **parks every prefab template** in the Bootstrap scene as an inactive instance. They have a `NetworkObject` component but `IsSpawned == false`. Calling:
+
+```csharp
+Object.FindObjectsByType<NetworkLootItem>(FindObjectsInactive.Include, FindObjectsSortMode.None)
+```
+
+returns those templates **alongside** the live runtime clones. Unfiltered counts are non-zero before any real spawn fires, which makes spawn-count assertions race-prone and false-positive.
+
+The fix is to filter by `NetworkObject.IsSpawned`. Reference helper for tests:
+
+```csharp
+// FriendSlopPrototypeSmokeTests.CountSpawned<T>
+private static int CountSpawned<T>() where T : NetworkBehaviour
+{
+    var items = Object.FindObjectsByType<T>(FindObjectsInactive.Include, FindObjectsSortMode.None);
+    var count = 0;
+    for (var i = 0; i < items.Length; i++)
+    {
+        if (items[i].NetworkObject != null && items[i].NetworkObject.IsSpawned)
+            count++;
+    }
+    return count;
+}
+```
+
+In runtime code, the same filter applies whenever you query the world for "live X" instead of "any X". `FindObjectsInactive.Exclude` is *not* sufficient — NGO can leave templates with active GameObjects, depending on prefab settings.
+
+## Rule 3 — Despawn before unload, scope find queries by scene
+
+When a planet or interior unloads, despawn its `NetworkObject`s explicitly on the server (`NetworkObject.Despawn(destroy: true)`) before tearing down the scene. Relying on `destroyWithScene` works *if* `SceneOriginHandle` was captured correctly (rule 1) — but explicit despawn is the only safe behaviour when the object should outlive scene unload (rare; e.g. a player's carried item across planets).
+
+When a query genuinely needs to be scoped to a single scene (loot in the active planet, doors in the current interior), check `gameObject.scene` after the find. Don't infer location from scene name — see SpaceshipSceneManagement.md rule "never infer location from current scene name".
+
+## Known stale sites
+
+These don't follow the contract yet and are queued in [BACKLOG.md](../BACKLOG.md) section 16b:
+
+- `MeteorShower.SpawnMeteor` ([Hazards/MeteorShower.cs:121](../Space%20Game/Assets/Scripts/Hazards/MeteorShower.cs)) — still uses `Instantiate` → `MoveGameObjectToScene` → `Spawn`. Convert to the active-scene swap.
+- `AnomalySpawner.Spawn` ([Hazards/AnomalySpawner.cs:71](../Space%20Game/Assets/Scripts/Hazards/AnomalySpawner.cs)) — defaults `destroyWithScene = false`, leaking anomalies into `DontDestroyOnLoad`.
+
+## Related
+
+- [Space Game/CLAUDE.md](../Space%20Game/CLAUDE.md) hard rule 9 — the short version of this contract.
+- [architecture.md](architecture.md) D-011 — the decision record and why this is load-bearing.
+- [FeatureIntegrationContracts.md](FeatureIntegrationContracts.md) "New Networked Spawn" — the contract every new spawn site should satisfy.
+- [SpaceshipSceneManagement.md](SpaceshipSceneManagement.md) — additive scene roles (`Bootstrap`, `ShipInterior`, `Planet_*`, `Travel_*`).

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -161,6 +161,26 @@ Each entry stays in the baseline until the main file lands under 400; drop the e
 
 **Status (2026-05-13).** Codified. Known stale sites: `MeteorShower.SpawnMeteor` (still uses post-Spawn move; queued in BACKLOG 16b) and `AnomalySpawner.Spawn` (still defaults `destroyWithScene = false`; queued in BACKLOG 16b).
 
+### D-012: Third-party assets are quarantined and import-once
+
+**Decision.** Asset Store / third-party packs do **not** live in `Assets/<PackName>/` on the feature path. Each pack goes in one quarantine root — `Assets/ThirdParty/<PackName>/`, or an embedded UPM package under `Packages/` when the pack is package-shaped — wrapped in its own `.asmdef` (`ThirdParty.<PackName>`, `autoReferenced` only when our runtime must call into it). A pack is imported **exactly once**, in a dedicated PR that does nothing else (`vendor: add <Pack> vX`). Demo / example / sample-scene folders inside the pack are deleted on import. If the pack adds a new binary extension, `.gitattributes` LFS coverage is extended in that same PR. Feature branches never import, re-import, or re-export a pack — they only reference one that already landed.
+
+**Why.** Quantified on `main` (2026-05-15): ~12,200 of the repo's files are vendor packs — `LowPolyInterior2` alone is 9,006 files, `LowPolyInterior` 1,714, `Plugins/Microdetail` 874, `HIVEMIND` 471 — versus ~360 for our own `Prefabs/`. When a pack sits on the feature path and gets re-imported per branch, every feature branch diffs by 1M+ lines, branches collide on vendor `.meta`/YAML, review becomes impossible, `.git` bloats (978 MB), and LFS bandwidth spikes (the direct cause of the [#25](https://github.com/TheSchlote/Friend-Slop/pull/25)/[#26](https://github.com/TheSchlote/Friend-Slop/pull/26) cost firefight). Quarantine + import-once keeps a feature PR reviewable as a feature PR, and an own-asmdef stops our code from coupling to a pack's churn.
+
+**Cost.** A one-time relocation of the packs already on `main` (staged in BACKLOG §17) and the discipline of the dedicated import PR. asmdef-wrapping a pack occasionally needs a few reference / `.asmref` fix-ups. One-time pain, permanent payoff.
+
+**Status (2026-05-15).** Policy set this commit. Mislocated on `main`: `HIVEMIND`, `LowPolyInterior`, `LowPolyInterior2`, `Plugins/Microdetail`, `YughuesFreeRockMaterials`, the junk `_Recovery/` crash dump, plus the friend-branch-only `LowPolyMegaBundle`. Relocation/purge is staged in BACKLOG §17. Until it lands: do not add new packs under `Assets/<root>` and do not re-import existing ones on a feature branch.
+
+### D-013: Short-lived branches, rebased, vendor imports isolated
+
+**Decision.** Feature branches are short-lived (target: merged within a few days), rebased on `main` before review rather than left to diverge, and scoped to one feature. A branch never carries a vendor-pack import alongside feature code — the import is its own prior PR (D-012). The lead may keep a single integration branch *only* for reconciling already-merged history; it is not a place to accumulate features. Contributor flow: branch off fresh `main` → add the feature as C# + `.asset` files (D-001/D-004/D-008) → rebase → PR. If the feature needs a new art pack, the D-012 pack PR lands first and the feature branch just references it.
+
+**Why.** The three friend branches (`interiors-changes`, `interior-variety`, `procedural-world-generation-tier-4-test`) are overlapping long-lived re-cuts of the same work, each re-importing the same packs; all are ~6 commits behind `main`, mutually conflicting (13–15 files), and effectively unmergeable. The cause is divergence over time plus vendor churn, **not** the feature code itself — there is only ~3.8K–14K lines of real gameplay across them, which is salvageable. Short-lived rebased branches with vendor factored out keep every contribution mergeable, which is the whole point of "let the friend keep adding features."
+
+**Cost.** The contributor rebases and keeps branches narrow instead of living in one long-running branch. The time saved not resolving million-line conflicts dwarfs it.
+
+**Status (2026-05-15).** Policy set. Existing divergent branches are reconciled per BACKLOG §17e (salvage real code onto fresh branches off `main`, drop the vendor noise). `merge/all-branches-to-main` is the only friend-work line that currently merges cleanly (0 conflicts vs `main`) and is the reference for "already integrated."
+
 ## Anti-patterns to refuse
 
 The following are explicitly out of scope for this project. If you find yourself reaching for one, stop and propose an alternative.
@@ -176,6 +196,9 @@ The following are explicitly out of scope for this project. If you find yourself
 - **Unfiltered `Object.FindObjectsByType<T>` over NGO types.** `NetworkPrefabsList` templates show up as inactive `IsSpawned=false` instances; filter on `NetworkObject.IsSpawned` (D-011).
 - **Procedural Canvas growth in `FriendSlopUI`.** Once the per-screen split lands, new screens get their own builder + class.
 - **Adding to a file already over 400 lines.** Split first.
+- **Importing an Asset Store pack into `Assets/<PackName>/`.** Quarantine under `Assets/ThirdParty/` (or an embedded `Packages/` package), own asmdef, dedicated import-once PR (D-012).
+- **Bundling a vendor-pack import with feature code, or re-importing a pack on a feature branch.** The pack lands once in its own PR; feature branches only reference it (D-012/D-013).
+- **Long-lived feature branches that diverge from `main`.** Short-lived, rebased, one feature per branch (D-013).
 
 ## Open questions
 
@@ -197,6 +220,8 @@ The following are explicitly out of scope for this project. If you find yourself
 - [`Space Game/CLAUDE.md`](../Space%20Game/CLAUDE.md) — agent-facing rules derived from this document.
 
 ## Roadmap (current)
+
+> **Top priority (2026-05-15): vendor quarantine + branch workflow (D-012/D-013), executed via BACKLOG §17.** The numbered roadmap below is paused behind it — divergent, vendor-laden branches are actively blocking the friend's contributions, which is the highest-leverage thing to fix for scalability.
 
 1. Guardrail docs and CLAUDE.md update. **(Done — this commit.)**
 2. Asmdef split (D-006).

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -66,12 +66,20 @@ The server triggers loads via `NetworkManager.SceneManager.LoadScene(path, LoadS
 
 **Cost.** Higher discipline required around scene ownership. Gameplay code must never `FindObjectOfType` across the additive set without filtering by scene. The `RoundManager` needs to know which planet scene is active, not "the scene."
 
-**Status.** `NetworkSceneTransitionService` is consumed by the round scene orchestration path through spawn-time dependency wiring. Gating criteria for marking the full multi-scene split complete:
+**Status (2026-05-13).** Largely landed for current tier 1–3 content.
 
-1. `Bootstrap`, `ShipInterior`, and at least one `Planet_*` scene exist as separate assets and are in Build Settings.
-2. `GameSceneCatalog` is the only place runtime code looks up scenes (no string literals).
-3. A multi-client PlayMode test exercises ship → planet → ship transitions and asserts player/round state at each step.
-4. Late-join is tested for each phase (lobby, ship-only, ship+planet active).
+- `Bootstrap` (`FriendSlopPrototype.unity`), `ShipInterior.unity`, and the authored planet scenes `Planet_StarterJunk`, `Planet_RustyMoon`, `Planet_VioletGiant` (plus `Planet_IcePlanet` for tier 3 testing) exist as separate assets and are registered in Build Settings via `MainGameSceneCatalog`.
+- `NetworkSceneTransitionService` is consumed by `RoundManager`/`PlanetSceneOrchestrator` through spawn-time dependency wiring. `GameSceneCatalog` is the runtime scene-lookup surface.
+- Interior scenes are loaded additively on demand by `InteriorEntrance` / `InteriorSceneBootstrapper` (see D-009).
+- Host-side ship lobby → active planet → success → ship return is covered by PlayMode smoke. **Still missing:** a true multi-client transition test, and late-join coverage for each phase (lobby, ship-only, ship+planet active).
+- Tier 2 mission variants (`Cobalt Trench`, `Volt Foundry`, `Wraith Halo`) intentionally share `Planet_RustyMoon.unity` as scene owner until a playtest needs unique visuals; see [SpaceshipSceneManagement.md](SpaceshipSceneManagement.md).
+
+Original gating criteria for "complete":
+
+1. `Bootstrap`, `ShipInterior`, and at least one `Planet_*` scene exist as separate assets and are in Build Settings. — **Done.**
+2. `GameSceneCatalog` is the only place runtime code looks up scenes (no string literals). — **Done.**
+3. A multi-client PlayMode test exercises ship → planet → ship transitions and asserts player/round state at each step. — **Pending.**
+4. Late-join is tested for each phase (lobby, ship-only, ship+planet active). — **Pending.**
 
 ### D-006: Asmdef boundaries (planned)
 
@@ -93,7 +101,7 @@ FriendSlop.Core         <-  FriendSlop.Networking  <-  FriendSlop.Gameplay  <-  
 
 **Cost.** A handful of `.asmdef` files and some namespace cleanup. One-time pain, permanent payoff.
 
-**Status.** Started. The first `FriendSlop.Core` foundation slice now owns the D-006 utility types; the remaining Runtime/Networking/Gameplay split is still pending.
+**Status (2026-05-13).** First slice landed: `FriendSlop.Core` (under `Scripts/Core/Foundation/`) owns the D-006 utility types and has no Netcode dependency. The full runtime is still in a single `FriendSlop.Runtime` assembly; carving Networking and Gameplay out of it is the next D-006 step. `FriendSlop.UI` and `FriendSlop.Editor` are already separate.
 
 ### D-007: File-size and singleton limits
 
@@ -103,7 +111,17 @@ FriendSlop.Core         <-  FriendSlop.Networking  <-  FriendSlop.Gameplay  <-  
 
 **Cost.** Some refactor churn. Worth it.
 
-**Status.** Several runtime files still exceed the cap and are frozen by `ArchitectureGuardrailTests` baselines. `FriendSlopUI`, `NetworkFirstPersonController`, `NetworkLootItem`, `PlayerInteractor`, `RoamingMonster`, and `RoundManager` are flagged for staged splits before significant additions.
+**Status (2026-05-13).** Earlier oversized files (`FriendSlopUI`, `NetworkFirstPersonController`, `NetworkLootItem`, `PlayerInteractor`, `RoundManager`, `NetworkSessionManager`) have all been carved below the default cap and removed from the baseline. Current `ArchitectureGuardrailTests.ExistingOversizedRuntimeFiles` baseline (all Interiors, carried over from the interiors merge):
+
+| File | Line count | Split notes |
+|---|---|---|
+| `Assets/Scripts/Interiors/InteriorLayoutGenerator.cs` | 1727 | Natural seams: required-room quotas, frontier expansion, downward-connector mirroring, fallback generation. |
+| `Assets/Scripts/Interiors/Blueprints/BlueprintEditorUI.cs` | 1005 | Editor-only; per-panel split. |
+| `Assets/Scripts/Interiors/InteriorSceneBootstrapper.cs` | 832 | Natural extraction: wall-patching / garage-door geometry, then materials, then door spawning. |
+| `Assets/Scripts/Interiors/Blueprints/BlueprintEditorController.cs` | 545 | Editor-only; smallest, safest first split. |
+| `Assets/Scripts/Interiors/InteriorSceneBootstrapper.Furniture.cs` | 527 | Extract pickers (`PickFurnitureForAnchor`, `HasTagOverlap`, etc.) into `.Furniture.Picking.cs`. |
+
+Each entry stays in the baseline until the main file lands under 400; drop the entry in the same PR that does the split.
 
 ### D-008: Tests at architectural seams
 
@@ -112,6 +130,36 @@ FriendSlop.Core         <-  FriendSlop.Networking  <-  FriendSlop.Gameplay  <-  
 **Why.** With no editor-driven verification, tests are the only thing standing between a vibe-coded change and a silently broken playtest. The seams (objective evaluation, phase transitions, scene transitions, RPC validation) are where logic goes wrong invisibly.
 
 **Cost.** Slower per-feature delivery. Bug-discovery time drops dramatically.
+
+### D-009: Interior generation is data-driven content
+
+**Decision.** Interior layouts are produced by feeding ScriptableObject definitions (`BuildingDefinition` + `RoomDefinition` + `FurnitureDefinition`, registered in `InteriorCatalog`) into a deterministic generator (`InteriorLayoutGenerator.Generate(definition, seed)`). The server picks the seed and writes it into `InteriorSessionData`; every client regenerates the same layout locally from that seed. Doors are `NetworkObject`s (open/close state syncs); furniture is deterministic-but-local (no `NetworkObject` per chair, every client picks identical pieces from the seed).
+
+**Why.** Procedural interiors without a hard determinism contract would either need every chair to be a `NetworkObject` (bandwidth/spawn-count blowup) or accept that clients see different rooms (correctness disaster). Pinning the contract to "server picks seed, all clients regenerate locally" gets us identical state without the network cost, *as long as* layout/furniture selection is a pure function of the seed. ScriptableObject-first content keeps the door open for blueprint authoring (D-010) and per-room variant pooling.
+
+**Cost.** Every line of generation code is on the path of the determinism contract. Any `Random` source, time stamp, or `FindObjectsByType` order dependence in generation is a correctness bug, not a style nit. Tests have to cover the pipeline both for output shape (rooms placed, constraints satisfied) and for stability under future renames — see the `FormerlySerializedAs` hazards in section 16c of the backlog.
+
+**Status (2026-05-13).** Pipeline is live: `InteriorEntrance` → `InteriorSessionData` → `InteriorSceneBootstrapper` → `InteriorLayoutGenerator` → spawned doors + local furniture. `InteriorLayoutGeneratorTests` covers a subset of the generator; `BlueprintLayoutBuilderTests`, `FurnitureSelectionTests`, `BuildingDefinitionRoomPoolTests`, and an `InteriorSceneBootstrapper` PlayMode smoke are queued in BACKLOG section 16c.
+
+### D-010: Blueprints as authored interior layouts
+
+**Decision.** When a building's interior should be hand-authored rather than rolled, the entry point is a `BlueprintAsset` that pins room placements and edge state (`Wall` / `Open` / `Door`) explicitly. `InteriorSessionData.Blueprint` overrides the procedural path: `BlueprintLayoutBuilder.Build(blueprint, definition)` produces the `InteriorLayout` directly, skipping the procedural door-policy pass because edge state is user-authored. Per-slot room variants (`Room_Residential_Bathroom_2x2.A` / `.B` etc., resolved via `RoomVariants.FindVariants` on family name + grid size) are still rolled per-spawn for variety without re-generating the layout.
+
+**Why.** Procedural is great for "generic dungeon"; it's wrong for places the design wants to be recognisable (the residential building, the friend's homebase). Going through the same `InteriorLayout` shape means the bootstrapper, door spawner, and furniture pipeline don't have to fork.
+
+**Cost.** A second code path with its own builder, editor (`BlueprintEditorController` / `BlueprintEditorUI`), and runtime entrance variant (`BlueprintEntrance`). `BlueprintLayoutBuilder` had zero coverage at the time this decision was recorded — see BACKLOG 16c for the queued `BlueprintLayoutBuilderTests`.
+
+**Status (2026-05-13).** Live. Used by the residential test building. Editor flow is in `Scripts/Interiors/Blueprints/` and is editor-only; the runtime builder is small (~80 lines) and pure.
+
+### D-011: NGO scene placement contract
+
+**Decision.** When spawning a `NetworkObject` into a scene other than the caller's, set the active scene to the target *before* `Instantiate` + `NetworkObject.Spawn(destroyWithScene: true)`. The canonical pattern is an active-scene swap around the whole spawn batch — see `ActiveSceneScope` in [`PrototypeNetworkBootstrapper.Spawning.cs`](../Space%20Game/Assets/Scripts/Networking/PrototypeNetworkBootstrapper.Spawning.cs) and the inlined equivalent in [`PlanetLootSpawner.TrySpawnNow`](../Space%20Game/Assets/Scripts/Loot/PlanetLootSpawner.cs). Do **not** rely on `SceneManager.MoveGameObjectToScene` after `Spawn`. When calling `Object.FindObjectsByType<T>(FindObjectsInactive.Include, …)` against an NGO type, filter by `NetworkObject.IsSpawned` if you care about live runtime state.
+
+**Why.** `NetworkObject.Spawn(destroyWithScene: true)` latches `SceneOriginHandle` to the GameObject's scene at the moment of spawn. With `EnableSceneManagement = true`, post-Spawn `MoveGameObjectToScene` calls fight NGO scene management and silently fail to stick (cost ~2 hours of debug time during PR #24). Separately, NGO parks `NetworkPrefabsList` templates as inactive instances in the Bootstrap scene; unfiltered `FindObjectsByType` returns them alongside real spawns, so unfiltered counts are non-zero before any real spawn fires.
+
+**Cost.** Every new spawn site has to use the pattern; tests that assert spawn counts have to filter. Codified as hard rule 9 in [`Space Game/CLAUDE.md`](../Space%20Game/CLAUDE.md) and detailed in [NetworkObjectSceneOwnership.md](NetworkObjectSceneOwnership.md).
+
+**Status (2026-05-13).** Codified. Known stale sites: `MeteorShower.SpawnMeteor` (still uses post-Spawn move; queued in BACKLOG 16b) and `AnomalySpawner.Spawn` (still defaults `destroyWithScene = false`; queued in BACKLOG 16b).
 
 ## Anti-patterns to refuse
 
@@ -123,6 +171,9 @@ The following are explicitly out of scope for this project. If you find yourself
 - **`Vector3.up` in physics or movement code.** Use `SphereWorld.GetGravityUp(position)`.
 - **Trusting client-supplied vectors in `ServerRpc`.** Validate range and clamp magnitude.
 - **`Instantiate`/`Destroy` for `NetworkObject`s.** Use `Spawn`/`Despawn` on the server.
+- **`SceneManager.MoveGameObjectToScene` after `NetworkObject.Spawn`.** Set the active scene before Instantiate + Spawn instead (D-011).
+- **Defaulting `destroyWithScene: false` on `NetworkObject.Spawn`.** Sends the object to `DontDestroyOnLoad`, which leaks it across planet transitions.
+- **Unfiltered `Object.FindObjectsByType<T>` over NGO types.** `NetworkPrefabsList` templates show up as inactive `IsSpawned=false` instances; filter on `NetworkObject.IsSpawned` (D-011).
 - **Procedural Canvas growth in `FriendSlopUI`.** Once the per-screen split lands, new screens get their own builder + class.
 - **Adding to a file already over 400 lines.** Split first.
 
@@ -135,6 +186,8 @@ The following are explicitly out of scope for this project. If you find yourself
 ## Related documents
 
 - [SpaceshipSceneManagement.md](SpaceshipSceneManagement.md) — current vertical slice, target scene layout, and scene-ownership rules.
+- [NetworkObjectSceneOwnership.md](NetworkObjectSceneOwnership.md) — D-011 in full: `ActiveSceneScope` pattern, `IsSpawned` filter, NGO scene-management gotchas.
+- [InteriorSystem.md](InteriorSystem.md) — D-009/D-010 in full: building/room/furniture data, procedural vs. blueprint paths, what's networked vs. local.
 - [FeatureIntegrationContracts.md](FeatureIntegrationContracts.md) — feature extension points and PR contracts for AI agents.
 - [SingletonAudit.md](SingletonAudit.md) — singleton audit, removals, and migration plan for remaining globals.
 - [RemainingFeatures.md](RemainingFeatures.md) — feature backlog organized by system.


### PR DESCRIPTION
## Why

The repo's scalability / collaboration blocker is **vendor-pack churn**, not the game code. ~12,200 vendor files already sit on `main` (`LowPolyInterior2` 9,006, `LowPolyInterior` 1,714, `Plugins/Microdetail` 874, `HIVEMIND` 471, …) vs ~360 of our own prefabs. Friend branches re-import these → 1M+ line diffs, 13–15-file mutual conflicts, 978 MB `.git`, recurring LFS-cost firefights (#25/#26). This PR sets the policy and the staged plan to fix it, and lands the previously-uncommitted Interiors documentation.

## Contents (docs + scaffold only — no code, no history rewrite, no pack moves)

1. **§16 backlog queue** — interiors-merge follow-up backlog (was never PR'd).
2. **§16a docs** — codifies the Interiors system + NGO scene contract across `CLAUDE.md`, `architecture.md` (D-009/010/011), `FeatureIntegrationContracts.md`, + new `docs/InteriorSystem.md`, `docs/NetworkObjectSceneOwnership.md`. (Was finished but sitting uncommitted in the working tree.)
3. **D-012 / D-013** — third-party assets quarantined under `Assets/ThirdParty/` (own asmdef, import-once PR); short-lived rebased branches with vendor imports isolated. `CLAUDE.md` hard rule 10. **BACKLOG §17** = staged relocation/purge plan (17a stop-the-bleed → 17b inventory → 17c relocate → **17d gated/destructive history purge** → 17e code salvage).
4. **§17a scaffold** — `Assets/ThirdParty/` + `README.md` with valid Unity `.meta`s, so the convention physically exists. `.gitattributes` binary audit: **clean** (existing LFS list covers everything; bloat is 100% re-imported text).

This branch was rebased onto latest `main` per the new D-013 policy (dogfooding).

## ⚠️ Overlap with #27

[#27](https://github.com/TheSchlote/Friend-Slop/pull/27) (docs consolidation, net −454 lines) also edits `BACKLOG.md`, `Space Game/CLAUDE.md`, `docs/FeatureIntegrationContracts.md`, `docs/architecture.md`. **Whichever merges second needs conflict resolution.** Ordering is a deliberate decision — recommend deciding before merging either.

## Test plan

Docs + 4 scaffold files only; zero `.cs` touched, so `dotnet build` / Unity tests are unaffected. No history rewrite; nothing in this PR is destructive. Pack relocation and the optional history purge are explicitly deferred to BACKLOG §17b+ (17d is gated on friend coordination).

🤖 Generated with [Claude Code](https://claude.com/claude-code)