### PR TITLE
ci: stop LFS-pulling pipeline on PRs (cut LFS bandwidth cost)

### DIFF
--- a/.github/workflows/build-and-deploy-itch.yml
+++ b/.github/workflows/build-and-deploy-itch.yml
@@ -1,5 +1,12 @@
 name: Build Windows and Deploy to itch.io
 
+# Cost control: the EditMode/PlayMode/scene-validate jobs each run `git lfs pull`,
+# and Git LFS bandwidth is the only thing on this repo that costs real money
+# (Actions runners are free on public repos). Every push to a branch with an
+# open PR used to trigger 3 LFS-pulling jobs. So the LFS-pulling pipeline now
+# runs ONLY on merges to `main` and manual dispatch — not on PRs / feature
+# branches. Pre-merge validation is the local `dotnet build` + Run-UnityTests
+# (see Space Game/CLAUDE.md); use `workflow_dispatch` for an on-demand cloud run.
 on:
   push:
     branches:
@@ -9,15 +16,6 @@ on:
       - '.github/workflows/build-and-deploy-itch.yml'
       - '.github/actions/**'
       - 'tools/**'
-  pull_request:
-    branches:
-      - main
-    paths:
-      - 'Space Game/**'
-      - '.github/workflows/build-and-deploy-itch.yml'
-      - '.github/actions/**'
-      - 'tools/**'
-  merge_group:
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Why

Per the GitHub usage CSV: **Git LFS bandwidth is the only thing on this repo billing real money** — public-repo Actions runners are free (every Actions row is `net=$0` despite ~$10 gross). The free 1 GB/mo LFS bandwidth was exhausted ~May 13–14; it's now ~$0.16/day fully-billed on heavy CI days.

The `editmode-tests`, `playmode-tests`, and `validate-scenes` jobs each run `git lfs pull`. They fired on **every push to any branch with an open PR** (3 LFS-pulling jobs × every friend-branch push) — that's the multi-GB spike on May 10–11.

## Change

Drop the `pull_request` and `merge_group` triggers. The pipeline now runs only on:
- push to `main` (path-filtered, unchanged)
- `workflow_dispatch` (manual on-demand)

`build-player`/`deploy-itch` job gating is unchanged (still main + dispatch only).

## Tradeoff (explicit)

PRs no longer get automated Unity test signal. Pre-merge validation moves to the local `dotnet build` + `Run-UnityTests.ps1` already documented as the no-editor check in `Space Game/CLAUDE.md`, plus `workflow_dispatch` for an on-demand cloud run. Acceptable for a 2-person cost-sensitive project; can be revisited by adding a cheap **LFS-free `dotnet build`** PR check (free on public repos, no LFS pull) if the lost signal is missed.

Note: this PR itself triggers one final old-trigger CI run (it touches the workflow path); the saving starts once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)