### PR TITLE
fix: §16b interiors-review code fixes (4)

### DIFF
--- a/Space Game/Assets/Scripts/Hazards/AnomalySpawner.cs
+++ b/Space Game/Assets/Scripts/Hazards/AnomalySpawner.cs
@@ -4,6 +4,7 @@ using FriendSlop.Player;
 using FriendSlop.Round;
 using Unity.Netcode;
 using UnityEngine;
+using UnityEngine.SceneManagement;
 
 namespace FriendSlop.Hazards
 {
@@ -67,11 +68,29 @@ namespace FriendSlop.Hazards
             var prefab = anomalyPrefabs[Random.Range(0, anomalyPrefabs.Length)];
             if (prefab == null) return;
 
-            var go = Instantiate(prefab, spawnPos, Quaternion.identity);
-            go.GetComponent<NetworkObject>().Spawn();
-            var orb = go.GetComponent<AnomalyOrb>();
-            orb.ServerInitialize(spawnPos);
-            _activeOrbs.Add(orb);
+            // Spawn into the active planet scene with destroyWithScene:true so anomalies
+            // tear down on planet travel instead of leaking into DontDestroyOnLoad (or a
+            // never-unloaded bootstrap scene). Same active-scene contract as loot and
+            // meteors; see PlanetLootSpawner.TrySpawnNow.
+            var targetScene = ResolveActivePlanetScene();
+            var previousActiveScene = SceneManager.GetActiveScene();
+            var shouldRestoreActiveScene = targetScene.IsValid() && targetScene.isLoaded && targetScene != previousActiveScene;
+            if (shouldRestoreActiveScene)
+                SceneManager.SetActiveScene(targetScene);
+
+            try
+            {
+                var go = Instantiate(prefab, spawnPos, Quaternion.identity);
+                go.GetComponent<NetworkObject>().Spawn(destroyWithScene: true);
+                var orb = go.GetComponent<AnomalyOrb>();
+                orb.ServerInitialize(spawnPos);
+                _activeOrbs.Add(orb);
+            }
+            finally
+            {
+                if (shouldRestoreActiveScene && previousActiveScene.IsValid() && previousActiveScene.isLoaded)
+                    SceneManager.SetActiveScene(previousActiveScene);
+            }
         }
 
         private static SphereWorld GetCurrentPlanet()
@@ -82,6 +101,28 @@ namespace FriendSlop.Hazards
                     return SphereWorld.GetClosest(player.transform.position);
             }
             return SphereWorld.GetClosest(Vector3.zero);
+        }
+
+        private Scene ResolveActivePlanetScene()
+        {
+            var round = RoundManagerRegistry.Current;
+            if (round != null)
+            {
+                var envs = PlanetEnvironment.ActiveEnvironments;
+                for (var i = 0; i < envs.Count; i++)
+                {
+                    var env = envs[i];
+                    if (env != null && round.IsEnvironmentActiveForCurrentPlanet(env))
+                    {
+                        var scene = env.gameObject.scene;
+                        if (scene.IsValid() && scene.isLoaded)
+                            return scene;
+                    }
+                }
+            }
+            // Scene-local spawners (e.g. Ice Planet's IceMine) already live in their
+            // planet scene; the global bootstrap spawner falls back to its own scene.
+            return gameObject.scene;
         }
     }
 }

--- a/Space Game/Assets/Scripts/Hazards/MeteorShower.cs
+++ b/Space Game/Assets/Scripts/Hazards/MeteorShower.cs
@@ -114,16 +114,29 @@ namespace FriendSlop.Hazards
             var direction = PickSpawnDirection(world);
             var spawnPos = world.GetSurfacePoint(direction, spawnAltitude);
 
-            var meteor = Instantiate(meteorPrefab, spawnPos, Quaternion.identity);
-            // Move into the planet scene so unloading the planet also tears down the meteor.
+            // Swap the active scene around Instantiate + Spawn so the meteor lands in the
+            // planet scene from the start and NetworkObject.Spawn(destroyWithScene:true)
+            // latches its SceneOriginHandle there. MoveGameObjectToScene after Spawn fights
+            // NGO scene management and is unreliable. Mirrors PlanetLootSpawner.TrySpawnNow.
             var targetScene = planetEnvironment != null ? planetEnvironment.gameObject.scene : gameObject.scene;
-            if (targetScene.IsValid() && targetScene.isLoaded && meteor.gameObject.scene != targetScene)
-                SceneManager.MoveGameObjectToScene(meteor.gameObject, targetScene);
+            var previousActiveScene = SceneManager.GetActiveScene();
+            var shouldRestoreActiveScene = targetScene.IsValid() && targetScene.isLoaded && targetScene != previousActiveScene;
+            if (shouldRestoreActiveScene)
+                SceneManager.SetActiveScene(targetScene);
 
-            var netObj = meteor.GetComponent<NetworkObject>();
-            if (netObj == null) { Destroy(meteor.gameObject); return; }
-            netObj.Spawn();
-            meteor.ServerInitialize();
+            try
+            {
+                var meteor = Instantiate(meteorPrefab, spawnPos, Quaternion.identity);
+                var netObj = meteor.GetComponent<NetworkObject>();
+                if (netObj == null) { Destroy(meteor.gameObject); return; }
+                netObj.Spawn(destroyWithScene: true);
+                meteor.ServerInitialize();
+            }
+            finally
+            {
+                if (shouldRestoreActiveScene && previousActiveScene.IsValid() && previousActiveScene.isLoaded)
+                    SceneManager.SetActiveScene(previousActiveScene);
+            }
         }
 
         private Vector3 PickSpawnDirection(SphereWorld world)

--- a/Space Game/Assets/Scripts/Loot/PlanetLootSpawner.cs
+++ b/Space Game/Assets/Scripts/Loot/PlanetLootSpawner.cs
@@ -154,7 +154,10 @@ namespace FriendSlop.Loot
         private bool IsCurrentActivePlanet()
         {
             CachePlanetEnvironment();
-            if (planetEnvironment == null) return true;
+            // No PlanetEnvironment in our hierarchy means we can't confirm we own the
+            // active planet - stay silent rather than spawning as if we were it, so a
+            // misconfigured/legacy spawner can't double-spawn loot onto another planet.
+            if (planetEnvironment == null) return false;
             var rm = RoundManagerRegistry.Current;
             return rm != null && rm.IsEnvironmentActiveForCurrentPlanet(planetEnvironment);
         }

--- a/Space Game/Assets/Tests/PlayMode/FriendSlopPrototypeSmokeTests.cs
+++ b/Space Game/Assets/Tests/PlayMode/FriendSlopPrototypeSmokeTests.cs
@@ -487,18 +487,6 @@ namespace FriendSlop.Tests.PlayMode
                 "Submitting all rocket parts and boarding should end the planet round successfully.");
         }
 
-        private static void AssertConnectedMenuLayoutDoesNotOverlap()
-        {
-            var joinCodePanel = FindActiveRect("JoinCodePanel");
-            var copyButton = FindActiveRect("Copy Code");
-            var lobbyQueue = FindActiveRect("LobbyQueue");
-
-            Assert.IsFalse(GetWorldRect(joinCodePanel).Overlaps(GetWorldRect(lobbyQueue)),
-                "The join-code panel should not overlap the lobby queue.");
-            Assert.IsFalse(GetWorldRect(copyButton).Overlaps(GetWorldRect(lobbyQueue)),
-                "The copy-code button should not overlap the lobby queue.");
-        }
-
         // Per-planet launchpad zone is now the source of truth - planet scenes own their
         // launchpad GameObject (e.g. StarterJunk's "Crash Dirt Patch"), so we validate
         // through the PlanetEnvironment contract rather than the legacy bootstrap names
@@ -609,30 +597,6 @@ namespace FriendSlop.Tests.PlayMode
             Assert.IsNotNull(spawn, $"{objectName} should exist in the prototype scene.");
             Assert.Greater(spawn.transform.position.normalized.y, 0.65f,
                 $"{objectName} should spawn near the launchpad hemisphere instead of across the planet.");
-        }
-
-        private static RectTransform FindActiveRect(string objectName)
-        {
-            var target = GameObject.Find(objectName);
-            Assert.IsNotNull(target, $"{objectName} should be active in the connected menu.");
-            var rect = target.GetComponent<RectTransform>();
-            Assert.IsNotNull(rect, $"{objectName} should have a RectTransform.");
-            return rect;
-        }
-
-        private static Rect GetWorldRect(RectTransform rect)
-        {
-            var corners = new Vector3[4];
-            rect.GetWorldCorners(corners);
-            var min = corners[0];
-            var max = corners[0];
-            for (var i = 1; i < corners.Length; i++)
-            {
-                min = Vector3.Min(min, corners[i]);
-                max = Vector3.Max(max, corners[i]);
-            }
-
-            return Rect.MinMaxRect(min.x, min.y, max.x, max.y);
         }
     }
 }


### PR DESCRIPTION
Fixes the 4 code issues surfaced in the PR #24 post-merge review (BACKLOG §16b). All four were re-verified still-present before fixing.

## Fixes
1. **`PlanetLootSpawner.IsCurrentActivePlanet()`** — returns `false` (was `true`) when no `PlanetEnvironment` is in the hierarchy, so a misconfigured/legacy spawner stays silent instead of spawning as if it owned the active planet.
2. **`MeteorShower.TrySpawnMeteor`** — replaced `Instantiate → MoveGameObjectToScene → Spawn()` with the active-scene swap around `Instantiate + Spawn` and `Spawn(destroyWithScene:true)`. NGO scene management fights post-Spawn moves (CLAUDE.md rule 9). Mirrors the established `PlanetLootSpawner.TrySpawnNow` precedent.
3. **`AnomalySpawner.TrySpawnOrb`** — resolves the active planet scene (`PlanetEnvironment.ActiveEnvironments` + `RoundManager.IsEnvironmentActiveForCurrentPlanet`), swaps the active scene around `Instantiate + Spawn`, and `Spawn(destroyWithScene:true)` so anomalies tear down on planet travel. The flag alone would be a fake fix — the global spawner's orb otherwise lands in the never-unloaded bootstrap scene. Adds a small `ResolveActivePlanetScene()` helper.
4. **Tests** — removed the never-called `AssertConnectedMenuLayoutDoesNotOverlap` and its now-orphaned `FindActiveRect` / `GetWorldRect` helpers.

## Verification
`dotnet build` of FriendSlop.Runtime + PlayMode + EditMode → **0 errors**. Diff is 4 files, +71/-50, no stray changes.

## Needs playtest
Per CLAUDE.md workflow expectations: the hazard spawn paths (MeteorShower / AnomalySpawner) have no automated multi-client coverage. This is code-complete and build-clean, but the meteor/anomaly scene-teardown-on-travel behavior should be confirmed in a human playtest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
