### PR TITLE
docs: correct stale Unity version 6000.3.4f1 → 6000.3.15f1

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Unity prototype for a small co-op sphere-world salvage run. Players host or join
 ## Project Snapshot
 
 - Unity project folder: `Space Game`
-- Unity version: `6000.3.4f1`
+- Unity version: `6000.3.15f1`
 - Bootstrap scene: `Space Game/Assets/Scenes/FriendSlopPrototype.unity`
 - Ship interior scene: `Space Game/Assets/Scenes/ShipInterior.unity`
 - Per-planet scenes: `Space Game/Assets/Scenes/Planet_*.unity` (each tier-2+ planet now owns its own additively-loaded scene)
@@ -86,7 +86,7 @@ Current authored content reaches prototype tier 4 (Hills and Valleys). Tier 3 ha
 
 ## Running Locally
 
-1. Open `Space Game` in Unity `6000.3.4f1`.
+1. Open `Space Game` in Unity `6000.3.15f1`.
 2. Open `Assets/Scenes/FriendSlopPrototype.unity`.
 3. Press Play.
 4. Use `Host LAN` for quick single-machine or LAN testing.
@@ -134,7 +134,7 @@ The script writes test results and logs to `$env:TEMP\FriendSlopUnityTests` by d
 Unity version drift check:
 
 ```powershell
-.\tools\Assert-UnityVersion.ps1 -ExpectedUnityVersion 6000.3.4f1
+.\tools\Assert-UnityVersion.ps1 -ExpectedUnityVersion 6000.3.15f1
 ```
 
 Unity YAML merge setup for this checkout:

--- a/docs/builder-audit.md
+++ b/docs/builder-audit.md
@@ -114,7 +114,7 @@ After any change to a builder, the right validation sequence is:
 git status
 
 # 2. Run Repair (not Rebuild) in batch mode.
-& 'T:\Unity\6000.3.4f1\Editor\Unity.exe' `
+& 'T:\Unity\6000.3.15f1\Editor\Unity.exe' `
    -batchmode -projectPath 'T:\Repos\Friend-Slop\Space Game' `
    -executeMethod FriendSlop.Editor.FriendSlopSceneBuilder.RepairPrototypeSceneBatch `
    -logFile "$env:TEMP\friend-slop-repair.log" -quit

--- a/docs/itch-cicd.md
+++ b/docs/itch-cicd.md
@@ -6,7 +6,7 @@ Workflow file: `.github/workflows/build-and-deploy-itch.yml`
 
 ## What It Does
 
-- Builds the Unity project in `Space Game` with Unity `6000.3.4f1`.
+- Builds the Unity project in `Space Game` (project pinned to `6000.3.15f1`; the GameCI build image is `6000.3.14f1` until a `6000.3.15f1` image is published).
 - Runs EditMode tests and a PlayMode scene smoke test before building.
 - Targets `StandaloneWindows64` (Linux/macOS targets were dropped in PR #25 to cut LFS + CI cost).
 - Stamps each CI build as `0.1.<GitHub run number>`, which appears in-game and on itch.io.


### PR DESCRIPTION
Corrects the stale Unity version in human-facing docs. Source of truth — `Space Game/ProjectSettings/ProjectVersion.txt` and the CI `PROJECT_UNITY_VERSION` — is `6000.3.15f1`, but the docs still cited the old `6000.3.4f1` in 5 places.

## Changes
- **README.md** (×3): Project Snapshot, "Running Locally" step 1, and the Unity-version-drift-check command → `6000.3.15f1`.
- **docs/builder-audit.md**: the `Unity.exe` Repair-batch command path → `6000.3.15f1`.
- **docs/itch-cicd.md**: reworded to be accurate rather than blindly substituted — the project is pinned to `6000.3.15f1` while the GameCI build image is `6000.3.14f1` (no `6000.3.15f1` GameCI image published yet), matching the workflow's own comment in `build-and-deploy-itch.yml`.

## Left intentionally untouched
`Space Game/Assets/Resources/PerformanceTestRunInfo.json` also contains `6000.3.4f1`, but it's a generated perf-run artifact (regenerated each run), not documentation — editing it would falsify a historical record.

## Verification
Docs-only; `git grep 6000.3.4f1 -- '*.md'` → no matches remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
