### PR TITLE
test: §8 objective Evaluate coverage (Quota/RocketAssembly)

### DIFF
--- a/Space Game/Assets/Tests/EditMode/Editor/QuotaObjectiveEvaluationTests.cs
+++ b/Space Game/Assets/Tests/EditMode/Editor/QuotaObjectiveEvaluationTests.cs
@@ -1,0 +1,145 @@
+using System.Reflection;
+using FriendSlop.Round;
+using NUnit.Framework;
+using UnityEngine;
+
+namespace FriendSlop.Tests.EditMode
+{
+    // D-008 / CLAUDE hard-rule 7: every RoundObjective subclass needs Evaluate coverage.
+    // RoundObjectiveTextTests only exercises QuotaObjective's copy; the win/lose branches
+    // (target resolution, boarding gate, timer-fail) were untested before this.
+    public class QuotaObjectiveEvaluationTests
+    {
+        [Test]
+        public void Evaluate_CollectedMeetsTarget_NoBoardingRequired_Succeeds()
+        {
+            WithQuota((round, objective) =>
+            {
+                SetField(objective, "requireBoarding", false);
+                round.Quota.Value = 500;
+
+                round.CollectedValue.Value = 500;
+                Assert.AreEqual(ObjectiveStatus.Success, objective.Evaluate(round));
+
+                round.CollectedValue.Value = 600;
+                Assert.AreEqual(ObjectiveStatus.Success, objective.Evaluate(round));
+            });
+        }
+
+        [Test]
+        public void Evaluate_CollectedBelowTarget_NoTimer_StaysPending()
+        {
+            WithQuota((round, objective) =>
+            {
+                SetField(objective, "requireBoarding", false);
+                round.Quota.Value = 500;
+                round.CollectedValue.Value = 499;
+
+                Assert.AreEqual(ObjectiveStatus.Pending, objective.Evaluate(round));
+            });
+        }
+
+        [Test]
+        public void Evaluate_TimerExpiredBelowTarget_Fails()
+        {
+            WithQuota((round, objective) =>
+            {
+                SetField(objective, "requireBoarding", false);
+                SetField(round, "roundLengthSeconds", 120f); // HasActiveTimer => roundLengthSeconds > 0
+                round.Quota.Value = 500;
+                round.CollectedValue.Value = 100;
+                round.TimeRemaining.Value = 0f;
+
+                Assert.AreEqual(ObjectiveStatus.Failed, objective.Evaluate(round));
+            });
+        }
+
+        [Test]
+        public void Evaluate_TimerExpiredBelowTarget_FailDisabled_StaysPending()
+        {
+            WithQuota((round, objective) =>
+            {
+                SetField(objective, "requireBoarding", false);
+                SetField(objective, "failOnTimerExpired", false);
+                SetField(round, "roundLengthSeconds", 120f);
+                round.Quota.Value = 500;
+                round.CollectedValue.Value = 100;
+                round.TimeRemaining.Value = 0f;
+
+                Assert.AreEqual(ObjectiveStatus.Pending, objective.Evaluate(round));
+            });
+        }
+
+        [Test]
+        public void Evaluate_QuotaOverride_TakesPrecedenceOverRoundQuota()
+        {
+            WithQuota((round, objective) =>
+            {
+                SetField(objective, "requireBoarding", false);
+                SetField(objective, "quotaOverride", 1000);
+                round.Quota.Value = 200; // would be met by 300 if it were the target
+
+                round.CollectedValue.Value = 300;
+                Assert.AreEqual(ObjectiveStatus.Pending, objective.Evaluate(round),
+                    "Override target (1000) must be used, not round.Quota (200).");
+
+                round.CollectedValue.Value = 1000;
+                Assert.AreEqual(ObjectiveStatus.Success, objective.Evaluate(round));
+            });
+        }
+
+        [Test]
+        public void Evaluate_TargetFloorsAtOne_WhenRoundQuotaIsZero()
+        {
+            WithQuota((round, objective) =>
+            {
+                SetField(objective, "requireBoarding", false);
+                round.Quota.Value = 0; // ResolveTarget => Mathf.Max(1, 0)
+
+                round.CollectedValue.Value = 0;
+                Assert.AreEqual(ObjectiveStatus.Pending, objective.Evaluate(round));
+
+                round.CollectedValue.Value = 1;
+                Assert.AreEqual(ObjectiveStatus.Success, objective.Evaluate(round));
+            });
+        }
+
+        [Test]
+        public void Evaluate_BoardingRequired_NotEveryoneBoarded_StaysPending()
+        {
+            WithQuota((round, objective) =>
+            {
+                // requireBoarding defaults true; with no NetworkManager connected==0, so the
+                // boarding gate can never be satisfied and quota-met must NOT resolve Success.
+                round.Quota.Value = 100;
+                round.CollectedValue.Value = 500;
+                round.PlayersBoarded.Value = 0;
+
+                Assert.AreEqual(ObjectiveStatus.Pending, objective.Evaluate(round));
+            });
+        }
+
+        private static void WithQuota(System.Action<RoundManager, QuotaObjective> body)
+        {
+            var roundObject = new GameObject("Round Manager Quota Test");
+            var objective = ScriptableObject.CreateInstance<QuotaObjective>();
+            try
+            {
+                var round = roundObject.AddComponent<RoundManager>();
+                body(round, objective);
+            }
+            finally
+            {
+                Object.DestroyImmediate(objective);
+                Object.DestroyImmediate(roundObject);
+            }
+        }
+
+        private static void SetField(object target, string name, object value)
+        {
+            var field = target.GetType().GetField(name, BindingFlags.Instance | BindingFlags.NonPublic);
+            Assert.IsNotNull(field, $"Field {name} not found on {target.GetType().Name}");
+            field.SetValue(target, value);
+        }
+    }
+}

--- a/Space Game/Assets/Tests/EditMode/Editor/QuotaObjectiveEvaluationTests.cs.meta
+++ b/Space Game/Assets/Tests/EditMode/Editor/QuotaObjectiveEvaluationTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: bfc2f79416325aa47a211698195dba8e

--- a/Space Game/Assets/Tests/EditMode/Editor/RocketAssemblyObjectiveEvaluationTests.cs
+++ b/Space Game/Assets/Tests/EditMode/Editor/RocketAssemblyObjectiveEvaluationTests.cs
@@ -1,0 +1,124 @@
+using System.Reflection;
+using FriendSlop.Round;
+using NUnit.Framework;
+using UnityEngine;
+
+namespace FriendSlop.Tests.EditMode
+{
+    // D-008 / CLAUDE hard-rule 7. The Success path delegates to
+    // RoundStateUtility.IsLaunchReady (truth table already covered by
+    // RoundStateUtilityTests); these tests pin the objective's OWN branches:
+    // the timer-fail decision, the quota cushion, and the fail-disabled gate.
+    public class RocketAssemblyObjectiveEvaluationTests
+    {
+        [Test]
+        public void Evaluate_NotLaunchReady_NoTimer_StaysPending()
+        {
+            WithRocket((round, objective) =>
+            {
+                round.RocketAssembled.Value = false;
+                Assert.AreEqual(ObjectiveStatus.Pending, objective.Evaluate(round));
+            });
+        }
+
+        [Test]
+        public void Evaluate_TimerExpiredBelowQuota_Fails()
+        {
+            WithRocket((round, objective) =>
+            {
+                SetField(round, "roundLengthSeconds", 120f);
+                round.Quota.Value = 500;
+                round.CollectedValue.Value = 100;
+                round.TimeRemaining.Value = 0f;
+
+                Assert.AreEqual(ObjectiveStatus.Failed, objective.Evaluate(round));
+            });
+        }
+
+        [Test]
+        public void Evaluate_TimerExpiredButQuotaCushionMet_StaysPending()
+        {
+            WithRocket((round, objective) =>
+            {
+                SetField(round, "roundLengthSeconds", 120f);
+                round.Quota.Value = 500;
+                round.CollectedValue.Value = 500; // not < Max(quota, minQuotaToAvoidFail)
+                round.TimeRemaining.Value = 0f;
+
+                Assert.AreEqual(ObjectiveStatus.Pending, objective.Evaluate(round),
+                    "Meeting the quota by timer expiry avoids the rocket-fail.");
+            });
+        }
+
+        [Test]
+        public void Evaluate_MinQuotaToAvoidFail_RaisesTheFailBar()
+        {
+            WithRocket((round, objective) =>
+            {
+                SetField(round, "roundLengthSeconds", 120f);
+                SetField(objective, "minQuotaToAvoidFail", 800);
+                round.Quota.Value = 100; // Max(100, 800) => 800
+                round.TimeRemaining.Value = 0f;
+
+                round.CollectedValue.Value = 500;
+                Assert.AreEqual(ObjectiveStatus.Failed, objective.Evaluate(round),
+                    "500 < Max(quota 100, minQuotaToAvoidFail 800) must fail.");
+
+                round.CollectedValue.Value = 800;
+                Assert.AreEqual(ObjectiveStatus.Pending, objective.Evaluate(round));
+            });
+        }
+
+        [Test]
+        public void Evaluate_TimerExpired_FailDisabled_StaysPending()
+        {
+            WithRocket((round, objective) =>
+            {
+                SetField(objective, "failOnTimerExpired", false);
+                SetField(round, "roundLengthSeconds", 120f);
+                round.Quota.Value = 500;
+                round.CollectedValue.Value = 0;
+                round.TimeRemaining.Value = 0f;
+
+                Assert.AreEqual(ObjectiveStatus.Pending, objective.Evaluate(round));
+            });
+        }
+
+        [Test]
+        public void Evaluate_RocketAssembledButNoConnectedPlayers_StaysPending()
+        {
+            WithRocket((round, objective) =>
+            {
+                // IsLaunchReady requires connected players; with no NetworkManager
+                // connected==0, so an assembled rocket alone must not win.
+                round.RocketAssembled.Value = true;
+                round.PlayersBoarded.Value = 5;
+
+                Assert.AreEqual(ObjectiveStatus.Pending, objective.Evaluate(round));
+            });
+        }
+
+        private static void WithRocket(System.Action<RoundManager, RocketAssemblyObjective> body)
+        {
+            var roundObject = new GameObject("Round Manager Rocket Test");
+            var objective = ScriptableObject.CreateInstance<RocketAssemblyObjective>();
+            try
+            {
+                var round = roundObject.AddComponent<RoundManager>();
+                body(round, objective);
+            }
+            finally
+            {
+                Object.DestroyImmediate(objective);
+                Object.DestroyImmediate(roundObject);
+            }
+        }
+
+        private static void SetField(object target, string name, object value)
+        {
+            var field = target.GetType().GetField(name, BindingFlags.Instance | BindingFlags.NonPublic);
+            Assert.IsNotNull(field, $"Field {name} not found on {target.GetType().Name}");
+            field.SetValue(target, value);
+        }
+    }
+}

--- a/Space Game/Assets/Tests/EditMode/Editor/RocketAssemblyObjectiveEvaluationTests.cs.meta
+++ b/Space Game/Assets/Tests/EditMode/Editor/RocketAssemblyObjectiveEvaluationTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 262a64332112cde42922fb8013ce07f6


### PR DESCRIPTION
## Summary
- Adds EditMode `Evaluate` tests for `QuotaObjective` and `RocketAssemblyObjective` — the two `RoundObjective` subclasses that had only result-text coverage. Closes the D-008 / CLAUDE hard-rule-7 gap (`SurvivalObjective` was already covered).
- Branches exercised: target resolution (override vs round quota vs the `Max(1,…)` floor), the `requireBoarding` gate, `failOnTimerExpired` vs fail-disabled, the quota cushion (`minQuotaToAvoidFail`), and the `IsLaunchReady` delegation boundary.
- Mirrors the existing `SurvivalObjectiveExtractionTests` harness (bare `AddComponent<RoundManager>`, reflection `SetField` for private serialized fields). No production code changed.

## Test plan
- [x] Headless batchmode EditMode — `result=Passed total=137 passed=137 failed=0 skipped=0`, zero regression
- [ ] CI EditMode green on the PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)