### PR TITLE
test: extract + cover RoundManager final-tier success latch

### DIFF
--- a/Space Game/Assets/Scripts/Core/Foundation/RoundStateUtility.cs
+++ b/Space Game/Assets/Scripts/Core/Foundation/RoundStateUtility.cs
@@ -35,6 +35,23 @@ namespace FriendSlop.Round
             return (expectedToLoad, readyCount);
         }
 
+        // Final-tier success is counted exactly once per cleared run: Evaluate polls every
+        // server frame and Success can be re-entered, so the recorded latch guards against
+        // double-counting ExpeditionsCompleted. The round lifecycle clears the latch on
+        // restart/return-to-lobby; this only decides whether *this* clear should count.
+        public static (int ExpeditionsCompleted, bool FinalTierSuccessRecorded) RecordFinalTierSuccess(
+            bool hasReachedFinalTier,
+            bool finalTierSuccessRecorded,
+            int expeditionsCompleted)
+        {
+            if (hasReachedFinalTier && !finalTierSuccessRecorded)
+            {
+                return (expeditionsCompleted + 1, true);
+            }
+
+            return (expeditionsCompleted, finalTierSuccessRecorded);
+        }
+
         public static bool IsLaunchReady(bool rocketAssembled, int boardedPlayerCount, int connectedPlayerCount)
         {
             if (!rocketAssembled || connectedPlayerCount <= 0)

--- a/Space Game/Assets/Scripts/Round/RoundManager.cs
+++ b/Space Game/Assets/Scripts/Round/RoundManager.cs
@@ -374,11 +374,12 @@ namespace FriendSlop.Round
             // in sync with whichever subset was rolled.
             if (phase == RoundPhase.Success)
             {
-                if (HasReachedFinalTier && !finalTierSuccessRecorded)
-                {
-                    ExpeditionsCompleted.Value++;
-                    finalTierSuccessRecorded = true;
-                }
+                var finalTierLatch = RoundStateUtility.RecordFinalTierSuccess(
+                    HasReachedFinalTier,
+                    finalTierSuccessRecorded,
+                    ExpeditionsCompleted.Value);
+                ExpeditionsCompleted.Value = finalTierLatch.ExpeditionsCompleted;
+                finalTierSuccessRecorded = finalTierLatch.FinalTierSuccessRecorded;
 
                 ServerRollNextPlanetChoices();
                 // Pre-select the first offered planet so the Travel button has a sensible

--- a/Space Game/Assets/Tests/EditMode/Editor/RoundStateUtilityTests.cs
+++ b/Space Game/Assets/Tests/EditMode/Editor/RoundStateUtilityTests.cs
@@ -72,5 +72,26 @@ namespace FriendSlop.Tests.EditMode
             Assert.AreEqual(expectedExpectedToLoad, result.ExpectedToLoad);
             Assert.AreEqual(expectedReadyCount, result.ReadyCount);
         }
+
+        [TestCase(true, false, 0, 1, true)]
+        [TestCase(true, false, 7, 8, true)]
+        [TestCase(true, true, 3, 3, true)]
+        [TestCase(false, false, 2, 2, false)]
+        [TestCase(false, true, 5, 5, true)]
+        public void RecordFinalTierSuccess_CountsEachFinalTierClearExactlyOnce(
+            bool hasReachedFinalTier,
+            bool finalTierSuccessRecorded,
+            int expeditionsCompleted,
+            int expectedExpeditionsCompleted,
+            bool expectedRecorded)
+        {
+            var result = RoundStateUtility.RecordFinalTierSuccess(
+                hasReachedFinalTier,
+                finalTierSuccessRecorded,
+                expeditionsCompleted);
+
+            Assert.AreEqual(expectedExpeditionsCompleted, result.ExpeditionsCompleted);
+            Assert.AreEqual(expectedRecorded, result.FinalTierSuccessRecorded);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- The other half of roadmap #8 (RoundManager phase-transition state machine). `ServerSetPhase`/`Update` hard-return on `!IsServer`, so a bare EditMode `RoundManager` can't drive the phase machine and a PlayMode NGO host harness is disproportionate for pure decision logic.
- Extracts the final-tier expedition latch out of `ServerSetPhase` into a pure `RoundStateUtility.RecordFinalTierSuccess` helper, mirroring the existing `RemoveDisconnectedLoadingPlayer` tuple-return pattern (`FriendSlop.Core`, Netcode-free).
- Behavior-preserving: helper returns the same `(ExpeditionsCompleted, FinalTierSuccessRecorded)` the inline block produced; the call site assigns the tuple back exactly as `RemoveDisconnectedLoadingPlayer`'s does.
- Adds 5 parametrized EditMode cases covering the latch invariant: one `ExpeditionsCompleted` increment per cleared final-tier run, idempotent under `Evaluate`'s per-frame polling, no-op when not at the final tier.
- Sets up roadmap #9 (§3 run-loop).

## Test plan
- [x] `dotnet build FriendSlop.Runtime.csproj` — 0 errors / 0 warnings
- [x] `dotnet build FriendSlop.EditModeTests.csproj` — 0 errors / 0 warnings
- [x] Headless EditMode (`Run-UnityTests.ps1 -TestPlatform EditMode`): results XML `result=Passed total=134 passed=134 failed=0` (129 base + 5 new; `RoundStateUtilityTests` 30 → 35; zero regressions)
- [ ] No playtest needed — pure logic + unit tests, no scene/visual surface

🤖 Generated with [Claude Code](https://claude.com/claude-code)