### PR TITLE
test: §16c #1 BlueprintLayoutBuilderTests + close §16b BACKLOG

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -310,16 +310,18 @@ The whole Interiors system was invisible to `CLAUDE.md` and `docs/architecture.m
 - **New `docs/InteriorSystem.md`** — full pipeline overview, procedural vs. blueprint path, networked-vs-local table, known oversized files.
 - **New `docs/NetworkObjectSceneOwnership.md`** — codifies the active-scene-before-Spawn pattern, the `IsSpawned` filter, despawn-before-unload, and the known stale sites (`MeteorShower`, `AnomalySpawner`) queued in 16b.
 
-### 16b. Code issues surfaced during the review
+### 16b. Code issues surfaced during the review — **Done 2026-05-15 (PR #33)**
 
-- **`PlanetLootSpawner.IsCurrentActivePlanet()`** ([line 142-148](Space%20Game/Assets/Scripts/Loot/PlanetLootSpawner.cs)) returns `true` when `planetEnvironment == null`. Should default to `false` — current behavior silently runs as the active spawner when env config is missing/broken.
-- **`MeteorShower`** ([line 121](Space%20Game/Assets/Scripts/Hazards/MeteorShower.cs)) still uses the old `Instantiate → MoveGameObjectToScene → Spawn` anti-pattern. Convert to `ActiveSceneScope`.
-- **`AnomalySpawner.Spawn()`** ([line 71](Space%20Game/Assets/Scripts/Hazards/AnomalySpawner.cs)) defaults `destroyWithScene=false`, leaking anomalies into `DontDestroyOnLoad` across planet transitions. Verify intent; likely should be `true`.
-- **Dead test code**: `AssertConnectedMenuLayoutDoesNotOverlap` at [FriendSlopPrototypeSmokeTests.cs:490](Space%20Game/Assets/Tests/PlayMode/FriendSlopPrototypeSmokeTests.cs) is defined but never called.
+All four items landed in [PR #33](https://github.com/TheSchlote/Friend-Slop/pull/33):
+
+- `PlanetLootSpawner.IsCurrentActivePlanet()` now returns `false` when no `PlanetEnvironment` is in the hierarchy (was `true`).
+- `MeteorShower.TrySpawnMeteor` swapped to the active-scene-swap-around-`Instantiate`+`Spawn(destroyWithScene:true)` pattern (matches `PlanetLootSpawner.TrySpawnNow`).
+- `AnomalySpawner.TrySpawnOrb` resolves the active planet scene, swaps active scene, and spawns with `destroyWithScene:true` — anomalies tear down on planet travel instead of leaking into `DontDestroyOnLoad`.
+- Dead test helper `AssertConnectedMenuLayoutDoesNotOverlap` (plus its orphaned `FindActiveRect`/`GetWorldRect` helpers) removed from `FriendSlopPrototypeSmokeTests`.
 
 ### 16c. Tests to add (priority order)
 
-1. **`BlueprintLayoutBuilderTests`** (EditMode) — `BlueprintLayoutBuilder.Build` currently has zero coverage and is the entire authored-layout pipeline. Pure static function, easy to test. Cover: empty/null blueprint returns empty layout, room placement, socket adjacency, edge-state overrides (Wall/Open/Door), variant picking, per-slot overrides.
+1. **`BlueprintLayoutBuilderTests`** (EditMode) — **Done 2026-05-19.** 16 EditMode tests covering empty/null inputs, placement + grid bookkeeping, floor-extent derivation, socket-adjacency connections, edge-state overrides (Wall/Open/Door + default), variant picking (across seeds + fallback), per-slot furniture-count override (with clone), and exit-room selection. Headless-validated EditMode 163/163. Pinned one current asymmetry: `Build(null, ...)` returns `FloorCount=0` (int default) while `Build(emptyBlueprint, ...)` returns `FloorCount=1` — callers must tolerate 0 from the null path.
 2. **`BuildingDefinitionRoomPoolTests`** (EditMode) — defensive against future `FormerlySerializedAs` renames. The recent `roomPool` → `optionalPool` rename silently broke `InteriorLayoutGeneratorTests`. A direct unit test on `BuildingDefinition.RoomPool` (combines `optionalPool` + `requiredRooms.Definition`) would catch the next one before it bites.
 3. **`PlanetLootSpawnerSceneOwnershipTests`** (PlayMode) — verifies the `ActiveSceneScope` fix on the Tier 2+ scene-owned spawner path that's not currently exercised. Load a Tier 2 scene, start host, assert all spawned loot ends up in the planet scene.
 4. **`FurnitureSelectionTests`** (EditMode) — `HasTagOverlap`, `IsCappedOut`, `PickFurnitureForAnchor`, `OverlapsExisting` in `InteriorSceneBootstrapper.Furniture.cs`. Pure static helpers; easy to test.

--- a/Space Game/Assets/Tests/EditMode/Editor/BlueprintLayoutBuilderTests.cs
+++ b/Space Game/Assets/Tests/EditMode/Editor/BlueprintLayoutBuilderTests.cs
@@ -1,0 +1,359 @@
+using System.Collections.Generic;
+using FriendSlop.Interiors;
+using FriendSlop.Interiors.Blueprints;
+using NUnit.Framework;
+using UnityEngine;
+
+namespace FriendSlop.Tests.EditMode
+{
+    public class BlueprintLayoutBuilderTests
+    {
+        // ── Helpers ────────────────────────────────────────────────────────────
+
+        private static RoomDefinition MakeRoom(string name, Vector2Int size,
+            SocketDirection[] sockets, RoomCategory cat = RoomCategory.Generic)
+        {
+            var def = ScriptableObject.CreateInstance<RoomDefinition>();
+            var so  = new UnityEditor.SerializedObject(def);
+            so.FindProperty("gridSize").vector2IntValue   = size;
+            so.FindProperty("category").enumValueIndex    = (int)cat;
+            so.FindProperty("weight").intValue            = 10;
+            var arr = so.FindProperty("sockets");
+            arr.arraySize = sockets.Length;
+            for (int i = 0; i < sockets.Length; i++)
+                arr.GetArrayElementAtIndex(i).enumValueIndex = (int)sockets[i];
+            so.ApplyModifiedPropertiesWithoutUndo();
+            def.name = name;
+            return def;
+        }
+
+        private static BuildingDefinition MakeBuilding(params RoomDefinition[] pool)
+        {
+            var def = ScriptableObject.CreateInstance<BuildingDefinition>();
+            var so  = new UnityEditor.SerializedObject(def);
+            var arr = so.FindProperty("optionalPool");
+            arr.arraySize = pool.Length;
+            for (int i = 0; i < pool.Length; i++)
+                arr.GetArrayElementAtIndex(i).objectReferenceValue = pool[i];
+            so.ApplyModifiedPropertiesWithoutUndo();
+            return def;
+        }
+
+        private static BlueprintAsset MakeBlueprint()
+        {
+            var bp = ScriptableObject.CreateInstance<BlueprintAsset>();
+            // Defensive — Unity ScriptableObject CreateInstance may bypass the
+            // field initialiser in some import paths.
+            bp.Rooms          ??= new List<RoomPlacement>();
+            bp.EdgeOverrides  ??= new List<EdgeOverride>();
+            return bp;
+        }
+
+        private static void AddPlacement(BlueprintAsset bp, RoomDefinition def,
+            Vector3Int gridPos, int rotation = 0)
+        {
+            bp.Rooms.Add(new RoomPlacement
+            {
+                Definition   = def,
+                GridPosition = gridPos,
+                Rotation     = rotation,
+            });
+        }
+
+        private static void AddEdgeOverride(BlueprintAsset bp, Vector3Int a, Vector3Int b, EdgeState state)
+        {
+            BlueprintAsset.NormalizePair(ref a, ref b);
+            bp.EdgeOverrides.Add(new EdgeOverride { CellA = a, CellB = b, State = state });
+        }
+
+        private static readonly SocketDirection[] AllFour =
+            { SocketDirection.North, SocketDirection.South, SocketDirection.East, SocketDirection.West };
+
+        // ── Empty / null inputs ────────────────────────────────────────────────
+
+        [Test]
+        public void Build_NullBlueprint_ReturnsEmptyLayoutWithIntDefaults()
+        {
+            // Pins current behaviour: a null blueprint short-circuits before the
+            // FloorCount/EntryFloor computation, so FloorCount stays at the int
+            // default of 0. The empty-blueprint path below returns FloorCount=1.
+            // Callers that may receive a null blueprint must tolerate FloorCount=0.
+            var layout = BlueprintLayoutBuilder.Build(null, MakeBuilding());
+
+            Assert.IsNotNull(layout);
+            Assert.AreEqual(0, layout.Rooms.Count);
+            Assert.AreEqual(0, layout.Grid.Count);
+            Assert.AreEqual(0, layout.Connections.Count);
+            Assert.AreEqual(0, layout.FloorCount);
+            Assert.AreEqual(0, layout.EntryFloor);
+            Assert.IsNull(layout.ExitRoom);
+        }
+
+        [Test]
+        public void Build_EmptyRoomList_ReturnsEmptyLayoutWithFloorCountOne()
+        {
+            // Asymmetric with the null case above: an empty Rooms list still runs
+            // the floor-extents pass, which special-cases Count==0 to FloorCount=1.
+            var bp = MakeBlueprint();
+
+            var layout = BlueprintLayoutBuilder.Build(bp, MakeBuilding());
+
+            Assert.AreEqual(0, layout.Rooms.Count);
+            Assert.AreEqual(1, layout.FloorCount);
+            Assert.AreEqual(0, layout.EntryFloor);
+            Assert.IsNull(layout.ExitRoom);
+        }
+
+        // ── Placement + grid bookkeeping ───────────────────────────────────────
+
+        [Test]
+        public void Build_PlacesEveryBlueprintRoom_AndPopulatesGrid()
+        {
+            var room = MakeRoom("R", Vector2Int.one, AllFour);
+            var bp   = MakeBlueprint();
+            AddPlacement(bp, room, new Vector3Int(0, 0, 0));
+            AddPlacement(bp, room, new Vector3Int(1, 0, 0));
+
+            var layout = BlueprintLayoutBuilder.Build(bp, MakeBuilding(room));
+
+            Assert.AreEqual(2, layout.Rooms.Count);
+            Assert.AreEqual(2, layout.Grid.Count);
+            Assert.IsTrue(layout.Grid.ContainsKey(new Vector3Int(0, 0, 0)));
+            Assert.IsTrue(layout.Grid.ContainsKey(new Vector3Int(1, 0, 0)));
+        }
+
+        [Test]
+        public void Build_OverlappingPlacement_IsSkipped()
+        {
+            var room = MakeRoom("R", Vector2Int.one, AllFour);
+            var bp   = MakeBlueprint();
+            AddPlacement(bp, room, new Vector3Int(0, 0, 0));
+            AddPlacement(bp, room, new Vector3Int(0, 0, 0));
+
+            var layout = BlueprintLayoutBuilder.Build(bp, MakeBuilding(room));
+
+            Assert.AreEqual(1, layout.Rooms.Count, "Second overlapping placement should be dropped.");
+            Assert.AreEqual(1, layout.Grid.Count);
+        }
+
+        [Test]
+        public void Build_FloorCountAndEntryFloor_AreDerivedFromYExtents()
+        {
+            var room = MakeRoom("R", Vector2Int.one, AllFour);
+            var bp   = MakeBlueprint();
+            AddPlacement(bp, room, new Vector3Int(0, 0, 0));
+            AddPlacement(bp, room, new Vector3Int(0, 2, 0));
+
+            var layout = BlueprintLayoutBuilder.Build(bp, MakeBuilding(room));
+
+            Assert.AreEqual(3, layout.FloorCount, "FloorCount = (maxY - minY) + 1.");
+            Assert.AreEqual(0, layout.EntryFloor, "EntryFloor = lowest placed Y.");
+        }
+
+        // ── Socket adjacency / connections ────────────────────────────────────
+
+        [Test]
+        public void Build_AdjacentRoomsWithMatchingSockets_RegisterAConnection()
+        {
+            var roomA = MakeRoom("A", Vector2Int.one, new[] { SocketDirection.North });
+            var roomB = MakeRoom("B", Vector2Int.one, new[] { SocketDirection.South });
+            var bp    = MakeBlueprint();
+            AddPlacement(bp, roomA, new Vector3Int(0, 0, 0));
+            AddPlacement(bp, roomB, new Vector3Int(0, 0, 1));
+
+            var layout = BlueprintLayoutBuilder.Build(bp, MakeBuilding(roomA, roomB));
+
+            Assert.AreEqual(1, layout.Connections.Count,
+                "Two rooms with matching opposite sockets should produce one connection.");
+            var conn = layout.Connections[0];
+            Assert.AreEqual(SocketDirection.North, conn.SocketA);
+            Assert.AreEqual(SocketDirection.South, conn.SocketB);
+            Assert.IsFalse(conn.IsOpenPassage,
+                "Default blueprint edge should be a closed door, not an open passage.");
+        }
+
+        [Test]
+        public void Build_AdjacentRoomsWithoutMatchingSocket_RegisterNoConnection()
+        {
+            // Room A has North socket but neighbour to the north has no South socket.
+            var roomA = MakeRoom("A", Vector2Int.one, new[] { SocketDirection.North });
+            var roomB = MakeRoom("B", Vector2Int.one, new[] { SocketDirection.North });
+            var bp    = MakeBlueprint();
+            AddPlacement(bp, roomA, new Vector3Int(0, 0, 0));
+            AddPlacement(bp, roomB, new Vector3Int(0, 0, 1));
+
+            var layout = BlueprintLayoutBuilder.Build(bp, MakeBuilding(roomA, roomB));
+
+            Assert.AreEqual(0, layout.Connections.Count);
+        }
+
+        // ── Edge overrides ────────────────────────────────────────────────────
+
+        [Test]
+        public void Build_EdgeOverrideWall_SuppressesConnection()
+        {
+            var roomA = MakeRoom("A", Vector2Int.one, new[] { SocketDirection.North });
+            var roomB = MakeRoom("B", Vector2Int.one, new[] { SocketDirection.South });
+            var bp    = MakeBlueprint();
+            AddPlacement(bp, roomA, new Vector3Int(0, 0, 0));
+            AddPlacement(bp, roomB, new Vector3Int(0, 0, 1));
+            AddEdgeOverride(bp, new Vector3Int(0, 0, 0), new Vector3Int(0, 0, 1), EdgeState.Wall);
+
+            var layout = BlueprintLayoutBuilder.Build(bp, MakeBuilding(roomA, roomB));
+
+            Assert.AreEqual(0, layout.Connections.Count, "Wall override must suppress the connection.");
+        }
+
+        [Test]
+        public void Build_EdgeOverrideOpen_MarksConnectionAsOpenPassage()
+        {
+            var roomA = MakeRoom("A", Vector2Int.one, new[] { SocketDirection.North });
+            var roomB = MakeRoom("B", Vector2Int.one, new[] { SocketDirection.South });
+            var bp    = MakeBlueprint();
+            AddPlacement(bp, roomA, new Vector3Int(0, 0, 0));
+            AddPlacement(bp, roomB, new Vector3Int(0, 0, 1));
+            AddEdgeOverride(bp, new Vector3Int(0, 0, 0), new Vector3Int(0, 0, 1), EdgeState.Open);
+
+            var layout = BlueprintLayoutBuilder.Build(bp, MakeBuilding(roomA, roomB));
+
+            Assert.AreEqual(1, layout.Connections.Count);
+            Assert.IsTrue(layout.Connections[0].IsOpenPassage,
+                "Open override must mark the connection as an open passage.");
+        }
+
+        [Test]
+        public void Build_EdgeOverrideDoor_MarksConnectionAsClosedDoor()
+        {
+            var roomA = MakeRoom("A", Vector2Int.one, new[] { SocketDirection.North });
+            var roomB = MakeRoom("B", Vector2Int.one, new[] { SocketDirection.South });
+            var bp    = MakeBlueprint();
+            AddPlacement(bp, roomA, new Vector3Int(0, 0, 0));
+            AddPlacement(bp, roomB, new Vector3Int(0, 0, 1));
+            AddEdgeOverride(bp, new Vector3Int(0, 0, 0), new Vector3Int(0, 0, 1), EdgeState.Door);
+
+            var layout = BlueprintLayoutBuilder.Build(bp, MakeBuilding(roomA, roomB));
+
+            Assert.AreEqual(1, layout.Connections.Count);
+            Assert.IsFalse(layout.Connections[0].IsOpenPassage,
+                "Door override must mark the connection as a closed door.");
+        }
+
+        // ── Variant picking ───────────────────────────────────────────────────
+
+        [Test]
+        public void Build_PicksVariantFromBuildingPool_BothVariantsReachable()
+        {
+            // Same family (suffix stripped) + same grid size = swappable variants.
+            var defA = MakeRoom("Bathroom_2x2.A", new Vector2Int(2, 2), AllFour);
+            var defB = MakeRoom("Bathroom_2x2.B", new Vector2Int(2, 2), AllFour);
+            var building = MakeBuilding(defA, defB);
+
+            bool sawA = false, sawB = false;
+            for (int seed = 0; seed < 64 && !(sawA && sawB); seed++)
+            {
+                Random.InitState(seed);
+                var bp = MakeBlueprint();
+                AddPlacement(bp, defA, Vector3Int.zero);
+                var layout = BlueprintLayoutBuilder.Build(bp, building);
+                var picked = layout.Rooms[0].Definition;
+                if (picked == defA) sawA = true;
+                else if (picked == defB) sawB = true;
+            }
+
+            Assert.IsTrue(sawA, "Variant A must be selectable across seeds.");
+            Assert.IsTrue(sawB, "Variant B must be selectable across seeds.");
+        }
+
+        [Test]
+        public void Build_NoVariantInPool_FallsBackToOriginalDef()
+        {
+            var def = MakeRoom("Solo_2x2", new Vector2Int(2, 2), AllFour);
+            // Building's pool has *no* matching family.
+            var unrelated = MakeRoom("Other_2x2", new Vector2Int(2, 2), AllFour);
+            var building  = MakeBuilding(unrelated);
+
+            var bp = MakeBlueprint();
+            AddPlacement(bp, def, Vector3Int.zero);
+
+            var layout = BlueprintLayoutBuilder.Build(bp, building);
+
+            Assert.AreEqual(1, layout.Rooms.Count);
+            Assert.AreSame(def, layout.Rooms[0].Definition,
+                "When no variants exist, the blueprint's stored def must be used directly.");
+        }
+
+        // ── Per-slot overrides (Phase 4) ──────────────────────────────────────
+
+        [Test]
+        public void Build_NoPerSlotOverride_UsesOriginalDefWithoutCloning()
+        {
+            var def = MakeRoom("R", Vector2Int.one, AllFour);
+            var bp  = MakeBlueprint();
+            AddPlacement(bp, def, Vector3Int.zero);
+
+            var layout = BlueprintLayoutBuilder.Build(bp, MakeBuilding(def));
+
+            Assert.AreSame(def, layout.Rooms[0].Definition,
+                "With no overrides, BlueprintLayoutBuilder must NOT clone the def.");
+        }
+
+        [Test]
+        public void Build_FurnitureCountRangeOverride_AppliesToClone()
+        {
+            var def = MakeRoom("R", Vector2Int.one, AllFour);
+            var bp  = MakeBlueprint();
+            bp.Rooms.Add(new RoomPlacement
+            {
+                Definition                  = def,
+                GridPosition                = Vector3Int.zero,
+                Rotation                    = 0,
+                OverrideFurnitureCountRange = true,
+                FurnitureCountRange         = new Vector2Int(7, 9),
+            });
+
+            var layout = BlueprintLayoutBuilder.Build(bp, MakeBuilding(def));
+
+            var placedDef = layout.Rooms[0].Definition;
+            Assert.AreNotSame(def, placedDef,
+                "Override path must produce a clone so the original asset is not mutated.");
+            Assert.AreEqual(new Vector2Int(7, 9), placedDef.FurnitureCountRange);
+            Assert.AreEqual(new Vector2Int(2, 4), def.FurnitureCountRange,
+                "Original RoomDefinition must keep its default range unchanged.");
+        }
+
+        // ── Exit-room selection ───────────────────────────────────────────────
+
+        [Test]
+        public void Build_MarksLowestSouthFacingRoomAsExit()
+        {
+            // Two floors. The exit room must be the one on the lowest floor that has
+            // a south-facing socket in world space.
+            var ground = MakeRoom("Ground", Vector2Int.one, new[] { SocketDirection.South, SocketDirection.North });
+            var upper  = MakeRoom("Upper",  Vector2Int.one, new[] { SocketDirection.South });
+            var bp     = MakeBlueprint();
+            AddPlacement(bp, ground, new Vector3Int(0, 0, 0));
+            AddPlacement(bp, upper,  new Vector3Int(0, 1, 0));
+
+            var layout = BlueprintLayoutBuilder.Build(bp, MakeBuilding(ground, upper));
+
+            Assert.IsNotNull(layout.ExitRoom);
+            Assert.AreEqual(0, layout.ExitRoom.GridPosition.y,
+                "Exit must sit on the entry floor (lowest Y).");
+            Assert.AreEqual(SocketDirection.South, layout.ExitSocket);
+        }
+
+        [Test]
+        public void Build_NoSouthFacingRoomOnEntryFloor_LeavesExitNull()
+        {
+            // Only entry-floor room has no south socket -> no eligible exit.
+            var room = MakeRoom("R", Vector2Int.one, new[] { SocketDirection.North });
+            var bp   = MakeBlueprint();
+            AddPlacement(bp, room, Vector3Int.zero);
+
+            var layout = BlueprintLayoutBuilder.Build(bp, MakeBuilding(room));
+
+            Assert.IsNull(layout.ExitRoom);
+            Assert.IsFalse(layout.ExitSocket.HasValue);
+        }
+    }
+}

--- a/Space Game/Assets/Tests/EditMode/Editor/BlueprintLayoutBuilderTests.cs.meta
+++ b/Space Game/Assets/Tests/EditMode/Editor/BlueprintLayoutBuilderTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 1d6a63dd4ce241d2a31f68fff7098d48

--- a/docs/InteriorSystem.md
+++ b/docs/InteriorSystem.md
@@ -83,7 +83,8 @@ Don't mix the two in a single building. Pick one entry component.
 - `Space Game/Assets/Scripts/Interiors/` — runtime data, entrance, exit, bootstrapper, generator, doors, minimap, events.
 - `Space Game/Assets/Scripts/Interiors/Blueprints/` — blueprint asset, builder, entrance variant, editor controller/UI, room variant helpers.
 - `Space Game/Assets/Scripts/Editor/Builders/FriendSlopSceneBuilder.Interiors*.cs` — editor-time prefab/scene generation for interior content.
-- `Space Game/Assets/Tests/EditMode/Editor/InteriorLayoutGeneratorTests.cs` — current EditMode coverage. More tests queued in [BACKLOG.md](../BACKLOG.md) section 16c (`BlueprintLayoutBuilderTests`, `BuildingDefinitionRoomPoolTests`, `FurnitureSelectionTests`, `InteriorCatalogTests`, plus a PlayMode smoke).
+- `Space Game/Assets/Tests/EditMode/Editor/InteriorLayoutGeneratorTests.cs` — procedural-pipeline EditMode coverage.
+- `Space Game/Assets/Tests/EditMode/Editor/BlueprintLayoutBuilderTests.cs` — authored-layout (blueprint) EditMode coverage; landed 2026-05-19, 16 tests. More tests queued in [BACKLOG.md](../BACKLOG.md) section 16c (`BuildingDefinitionRoomPoolTests`, `FurnitureSelectionTests`, `InteriorCatalogTests`, plus a PlayMode smoke).
 
 ## Known oversized files
 

--- a/docs/NetworkObjectSceneOwnership.md
+++ b/docs/NetworkObjectSceneOwnership.md
@@ -61,12 +61,9 @@ When a planet or interior unloads, despawn its `NetworkObject`s explicitly on th
 
 When a query genuinely needs to be scoped to a single scene (loot in the active planet, doors in the current interior), check `gameObject.scene` after the find. Don't infer location from scene name — see SpaceshipSceneManagement.md rule "never infer location from current scene name".
 
-## Known stale sites
+## Compliance status
 
-These don't follow the contract yet and are queued in [BACKLOG.md](../BACKLOG.md) section 16b:
-
-- `MeteorShower.SpawnMeteor` ([Hazards/MeteorShower.cs:121](../Space%20Game/Assets/Scripts/Hazards/MeteorShower.cs)) — still uses `Instantiate` → `MoveGameObjectToScene` → `Spawn`. Convert to the active-scene swap.
-- `AnomalySpawner.Spawn` ([Hazards/AnomalySpawner.cs:71](../Space%20Game/Assets/Scripts/Hazards/AnomalySpawner.cs)) — defaults `destroyWithScene = false`, leaking anomalies into `DontDestroyOnLoad`.
+As of 2026-05-15 every networked spawn site in the runtime follows this contract. The previously stale sites (`MeteorShower.TrySpawnMeteor`, `AnomalySpawner.TrySpawnOrb`) were brought into compliance in [PR #33](https://github.com/TheSchlote/Friend-Slop/pull/33). Add new offenders here if any appear in review.
 
 ## Related
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -139,7 +139,7 @@ Each entry stays in the baseline until the main file lands under 400; drop the e
 
 **Cost.** Every line of generation code is on the path of the determinism contract. Any `Random` source, time stamp, or `FindObjectsByType` order dependence in generation is a correctness bug, not a style nit. Tests have to cover the pipeline both for output shape (rooms placed, constraints satisfied) and for stability under future renames — see the `FormerlySerializedAs` hazards in section 16c of the backlog.
 
-**Status (2026-05-13).** Pipeline is live: `InteriorEntrance` → `InteriorSessionData` → `InteriorSceneBootstrapper` → `InteriorLayoutGenerator` → spawned doors + local furniture. `InteriorLayoutGeneratorTests` covers a subset of the generator; `BlueprintLayoutBuilderTests`, `FurnitureSelectionTests`, `BuildingDefinitionRoomPoolTests`, and an `InteriorSceneBootstrapper` PlayMode smoke are queued in BACKLOG section 16c.
+**Status (2026-05-19).** Pipeline is live: `InteriorEntrance` → `InteriorSessionData` → `InteriorSceneBootstrapper` → `InteriorLayoutGenerator` → spawned doors + local furniture. `InteriorLayoutGeneratorTests` covers a subset of the generator and `BlueprintLayoutBuilderTests` (landed 2026-05-19, 16 EditMode tests, BACKLOG 16c #1) covers the authored-layout builder. `FurnitureSelectionTests`, `BuildingDefinitionRoomPoolTests`, `InteriorCatalogTests`, and an `InteriorSceneBootstrapper` PlayMode smoke remain queued in BACKLOG section 16c.
 
 ### D-010: Blueprints as authored interior layouts
 
@@ -147,7 +147,7 @@ Each entry stays in the baseline until the main file lands under 400; drop the e
 
 **Why.** Procedural is great for "generic dungeon"; it's wrong for places the design wants to be recognisable (the residential building, the friend's homebase). Going through the same `InteriorLayout` shape means the bootstrapper, door spawner, and furniture pipeline don't have to fork.
 
-**Cost.** A second code path with its own builder, editor (`BlueprintEditorController` / `BlueprintEditorUI`), and runtime entrance variant (`BlueprintEntrance`). `BlueprintLayoutBuilder` had zero coverage at the time this decision was recorded — see BACKLOG 16c for the queued `BlueprintLayoutBuilderTests`.
+**Cost.** A second code path with its own builder, editor (`BlueprintEditorController` / `BlueprintEditorUI`), and runtime entrance variant (`BlueprintEntrance`). `BlueprintLayoutBuilder` had zero coverage at the time this decision was recorded; coverage landed 2026-05-19 as 16 EditMode tests in `BlueprintLayoutBuilderTests` (BACKLOG 16c #1).
 
 **Status (2026-05-13).** Live. Used by the residential test building. Editor flow is in `Scripts/Interiors/Blueprints/` and is editor-only; the runtime builder is small (~80 lines) and pure.
 
@@ -159,7 +159,7 @@ Each entry stays in the baseline until the main file lands under 400; drop the e
 
 **Cost.** Every new spawn site has to use the pattern; tests that assert spawn counts have to filter. Codified as hard rule 9 in [`Space Game/CLAUDE.md`](../Space%20Game/CLAUDE.md) and detailed in [NetworkObjectSceneOwnership.md](NetworkObjectSceneOwnership.md).
 
-**Status (2026-05-13).** Codified. Known stale sites: `MeteorShower.SpawnMeteor` (still uses post-Spawn move; queued in BACKLOG 16b) and `AnomalySpawner.Spawn` (still defaults `destroyWithScene = false`; queued in BACKLOG 16b).
+**Status (2026-05-15).** Codified and clean. Previously stale sites `MeteorShower.TrySpawnMeteor` and `AnomalySpawner.TrySpawnOrb` were brought into compliance in [PR #33](https://github.com/TheSchlote/Friend-Slop/pull/33) — both now swap the active scene around `Instantiate` + `Spawn(destroyWithScene:true)` per the contract.
 
 ### D-012: Third-party assets are quarantined and import-once
 


### PR DESCRIPTION
## Summary

- Adds **`BlueprintLayoutBuilderTests`** (16 EditMode tests) covering the entire §16c #1 surface for `BlueprintLayoutBuilder.Build` — empty/null inputs, placement + grid bookkeeping, floor-extent derivation, socket-adjacency connections, edge-state overrides (Wall/Open/Door + default), variant picking (across seeds + fallback), per-slot furniture-count override with clone, and exit-room selection. Headless-validated: **EditMode 163/163** (147 baseline + 16 new).
- Closes **BACKLOG §16b**: the four interior-review code fixes shipped in [PR #33](https://github.com/TheSchlote/Friend-Slop/pull/33) (2026-05-15) but the section still read as open. Replaces TODO bullets with a one-line "Done" status + shipped-changes summary so the next agent doesn't re-do landed work.
- **Doc sync** across three files where §16 status had drifted from main:
  - `docs/architecture.md` D-009 / D-010 — drop `BlueprintLayoutBuilderTests` from the queued list, note it landed today.
  - `docs/architecture.md` D-011 — flip status from "Codified. Known stale sites: MeteorShower + AnomalySpawner" to "Codified and clean" (PR #33 brought them into compliance).
  - `docs/NetworkObjectSceneOwnership.md` — replace the "Known stale sites" section with a "Compliance status" note.
  - `docs/InteriorSystem.md` — add the new test file to current coverage; remove from queued list.
- Pins one current asymmetry in test comments rather than smoothing it over: `Build(null, ...)` returns `FloorCount=0` (int default, early-return path); `Build(emptyBlueprint, ...)` returns `FloorCount=1` (special case in the floor-extents pass). Callers receiving a null blueprint must tolerate 0.

## Test plan

- [x] `dotnet build 'Space Game/FriendSlop.EditModeTests.csproj'` — 0 warnings, 0 errors
- [x] `tools/Run-UnityTests.ps1 -TestPlatform EditMode` — **163/163 pass** (was 147 before this PR)
- [ ] Manual review of the BACKLOG §16b/§16c #1 status edits + the three doc sync changes
- [ ] No PlayMode run needed: only EditMode tests added, no production code changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)