### PR TITLE
feat: §7 per-mission loot-value-budget model

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -155,6 +155,8 @@ Grooming questions:
 
 Recommendation: a **per-mission budget model** with a 120% guaranteed minimum and 200% potential ceiling. Each `PlanetDefinition` declares `quotaTarget` (already exists) plus a new `lootValueBudget`; the spawner rolls until total spawned value is in `[1.2 × quotaTarget, 2.0 × quotaTarget]`. Within budget, items come from a `LootPool.asset` rolled by rarity weights. Do not scale by crew size for v1 — too easy to game by ghost-joining.
 
+**Status 2026-05-19: code-side shipped.** `PlanetDefinition.lootValueBudget` (int, default 0) and a pure `LootBudget` helper (Min=1.2×, Max=2.0×, safety cap = 256 rolls) wire `PlanetLootSpawner` into a budget-driven loop: it cycles through `spawnPoints[]`, rolls until cumulative item value reaches the 1.2× floor, and skips individual rolls that would push past the 2.0× ceiling. `lootValueBudget == 0` keeps the legacy `spawnPoints × rollsPerSpawnPoint` behavior intact for every existing planet asset. EditMode-validated via `LootBudgetTests`. **Open follow-up: author `lootValueBudget` per-planet** (Starter Junk, Rusty Moon, Violet Giant, tier 3+) so the budget loop actually activates — currently every shipped `.asset` is at 0 (legacy).
+
 ## 8. Combat and item rules
 
 Laser gun and boxing gloves are implemented, but their role in co-op play needs rules. Friendly fire, stun duration, ammo refill, rarity, and grief potential should be decided before adding more weapons.

--- a/Space Game/Assets/Scripts/Loot/LootBudget.cs
+++ b/Space Game/Assets/Scripts/Loot/LootBudget.cs
@@ -1,0 +1,36 @@
+using UnityEngine;
+
+namespace FriendSlop.Loot
+{
+    // Pure helper for the per-mission loot-value budget model (BACKLOG §7).
+    // The spawner rolls until the cumulative item value reaches the guaranteed
+    // minimum (Min × budget); individual rolls that would push past the ceiling
+    // (Max × budget) are skipped. Kept as static helpers so the budget decision
+    // is unit-testable without standing up a NetworkManager.
+    public static class LootBudget
+    {
+        public const float MinFraction = 1.2f;
+        public const float MaxFraction = 2.0f;
+        public const int MaxRollsSafetyCap = 256;
+
+        public static int MinValueFor(int budget) =>
+            budget <= 0 ? 0 : Mathf.RoundToInt(budget * MinFraction);
+
+        public static int MaxValueFor(int budget) =>
+            budget <= 0 ? 0 : Mathf.RoundToInt(budget * MaxFraction);
+
+        // True once the cumulative spawned value has reached the guaranteed
+        // minimum; the spawner can stop rolling.
+        public static bool BudgetReached(int currentTotal, int budget) =>
+            budget > 0 && currentTotal >= MinValueFor(budget);
+
+        // True when accepting an item of `candidateValue` would keep the running
+        // total at or below the ceiling. Negative values are treated as zero.
+        public static bool ShouldAccept(int candidateValue, int currentTotal, int budget)
+        {
+            if (budget <= 0) return false;
+            var safeValue = Mathf.Max(0, candidateValue);
+            return currentTotal + safeValue <= MaxValueFor(budget);
+        }
+    }
+}

--- a/Space Game/Assets/Scripts/Loot/LootBudget.cs.meta
+++ b/Space Game/Assets/Scripts/Loot/LootBudget.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 529dd0656f59fa546b9df627e1937ffd

--- a/Space Game/Assets/Scripts/Loot/PlanetLootSpawner.cs
+++ b/Space Game/Assets/Scripts/Loot/PlanetLootSpawner.cs
@@ -109,32 +109,80 @@ namespace FriendSlop.Loot
 
             try
             {
-                for (var i = 0; i < spawnPoints.Length; i++)
-                {
-                    var spawn = spawnPoints[i];
-                    if (spawn == null) continue;
-
-                    for (var roll = 0; roll < rollsPerSpawnPoint; roll++)
-                    {
-                        var prefab = lootPool.Roll();
-                        if (prefab == null) continue;
-
-                        var pos = spawn.position + spawn.up * spawnSurfaceLift;
-                        var rot = spawn.rotation;
-                        var loot = Instantiate(prefab, pos, rot);
-                        loot.ServerSetSpawnPose(pos, rot);
-                        if (loot.NetworkObject != null)
-                        {
-                            loot.NetworkObject.Spawn(destroyWithScene: true);
-                            spawnedObjects.Add(loot.NetworkObject);
-                        }
-                    }
-                }
+                var budget = ResolveLootValueBudget();
+                if (budget > 0)
+                    SpawnByBudget(budget);
+                else
+                    SpawnLegacyPerPoint();
             }
             finally
             {
                 if (shouldRestoreActiveScene && previousActiveScene.IsValid() && previousActiveScene.isLoaded)
                     SceneManager.SetActiveScene(previousActiveScene);
+            }
+        }
+
+        private int ResolveLootValueBudget()
+        {
+            CachePlanetEnvironment();
+            return planetEnvironment != null && planetEnvironment.Planet != null
+                ? planetEnvironment.Planet.LootValueBudget
+                : 0;
+        }
+
+        private void SpawnLegacyPerPoint()
+        {
+            for (var i = 0; i < spawnPoints.Length; i++)
+            {
+                var spawn = spawnPoints[i];
+                if (spawn == null) continue;
+
+                for (var roll = 0; roll < rollsPerSpawnPoint; roll++)
+                {
+                    var prefab = lootPool.Roll();
+                    if (prefab == null) continue;
+                    SpawnLootAt(prefab, spawn);
+                }
+            }
+        }
+
+        private void SpawnByBudget(int budget)
+        {
+            // Walk the spawn points in order, cycling, until the budget loop
+            // signals it's done. Designers control density by adding more
+            // points (or duplicating a point) rather than by tuning rolls.
+            var validPoints = new List<Transform>(spawnPoints.Length);
+            for (var i = 0; i < spawnPoints.Length; i++)
+                if (spawnPoints[i] != null) validPoints.Add(spawnPoints[i]);
+            if (validPoints.Count == 0) return;
+
+            var pointIndex = 0;
+            var spawnedValue = 0;
+            for (var attempt = 0; attempt < LootBudget.MaxRollsSafetyCap; attempt++)
+            {
+                if (LootBudget.BudgetReached(spawnedValue, budget)) break;
+
+                var prefab = lootPool.Roll();
+                if (prefab == null) continue;
+                if (!LootBudget.ShouldAccept(prefab.Value, spawnedValue, budget)) continue;
+
+                var spawn = validPoints[pointIndex];
+                pointIndex = (pointIndex + 1) % validPoints.Count;
+                SpawnLootAt(prefab, spawn);
+                spawnedValue += Mathf.Max(0, prefab.Value);
+            }
+        }
+
+        private void SpawnLootAt(NetworkLootItem prefab, Transform spawn)
+        {
+            var pos = spawn.position + spawn.up * spawnSurfaceLift;
+            var rot = spawn.rotation;
+            var loot = Instantiate(prefab, pos, rot);
+            loot.ServerSetSpawnPose(pos, rot);
+            if (loot.NetworkObject != null)
+            {
+                loot.NetworkObject.Spawn(destroyWithScene: true);
+                spawnedObjects.Add(loot.NetworkObject);
             }
         }
 

--- a/Space Game/Assets/Scripts/Round/PlanetDefinition.cs
+++ b/Space Game/Assets/Scripts/Round/PlanetDefinition.cs
@@ -14,6 +14,13 @@ namespace FriendSlop.Round
         [SerializeField] private int quotaOverride;
         [SerializeField] private float roundLengthOverride;
 
+        [Header("Loot Budget (0 = legacy spawn-points × rolls)")]
+        [Tooltip("Target loot value for this planet. When > 0, PlanetLootSpawner ignores " +
+                 "rollsPerSpawnPoint and instead rolls until cumulative item value hits " +
+                 "1.2× this budget (guaranteed minimum); individual rolls that would push " +
+                 "past 2.0× (ceiling) are skipped. See BACKLOG §7.")]
+        [SerializeField, Min(0)] private int lootValueBudget;
+
         [Header("Objective (optional - falls back to RoundManager default)")]
         [SerializeField] private RoundObjective objective;
 
@@ -55,6 +62,7 @@ namespace FriendSlop.Round
         public int Tier => Mathf.Clamp(tier, 1, PlanetCatalog.MaxTier);
         public int QuotaOverride => quotaOverride;
         public float RoundLengthOverride => roundLengthOverride;
+        public int LootValueBudget => Mathf.Max(0, lootValueBudget);
         public Color SkyTint => skyTint;
         public Sprite PreviewIcon => previewIcon;
         public RoundObjective Objective => objective;

--- a/Space Game/Assets/Tests/EditMode/Editor/LootBudgetTests.cs
+++ b/Space Game/Assets/Tests/EditMode/Editor/LootBudgetTests.cs
@@ -1,0 +1,94 @@
+using FriendSlop.Loot;
+using NUnit.Framework;
+
+namespace FriendSlop.Tests.EditMode
+{
+    // Pins the per-mission loot-budget contract (BACKLOG §7):
+    //   - Minimum = 1.2× budget (rolling stops once reached).
+    //   - Maximum = 2.0× budget (individual rolls beyond ceiling are skipped).
+    //   - Budget == 0 is the legacy/disabled path (every accept fails, every
+    //     reach is false) so the spawner falls back to the per-point loop.
+    public class LootBudgetTests
+    {
+        [Test]
+        public void MinValueFor_AppliesFractionAndRoundsToNearestInt()
+        {
+            Assert.AreEqual(120, LootBudget.MinValueFor(100));
+            Assert.AreEqual(600, LootBudget.MinValueFor(500));
+        }
+
+        [Test]
+        public void MaxValueFor_AppliesFractionAndRoundsToNearestInt()
+        {
+            Assert.AreEqual(200, LootBudget.MaxValueFor(100));
+            Assert.AreEqual(1000, LootBudget.MaxValueFor(500));
+        }
+
+        [Test]
+        public void MinAndMaxValueFor_ReturnZeroForZeroOrNegativeBudget()
+        {
+            Assert.AreEqual(0, LootBudget.MinValueFor(0));
+            Assert.AreEqual(0, LootBudget.MaxValueFor(0));
+            Assert.AreEqual(0, LootBudget.MinValueFor(-100));
+            Assert.AreEqual(0, LootBudget.MaxValueFor(-100));
+        }
+
+        [Test]
+        public void BudgetReached_FalseBelowMin()
+        {
+            Assert.IsFalse(LootBudget.BudgetReached(0, 500));
+            Assert.IsFalse(LootBudget.BudgetReached(100, 500));
+            Assert.IsFalse(LootBudget.BudgetReached(599, 500), "599 < 600 = 1.2 × 500");
+        }
+
+        [Test]
+        public void BudgetReached_TrueAtAndAboveMin()
+        {
+            Assert.IsTrue(LootBudget.BudgetReached(600, 500), "600 = 1.2 × 500");
+            Assert.IsTrue(LootBudget.BudgetReached(800, 500));
+            Assert.IsTrue(LootBudget.BudgetReached(1000, 500), "ceiling counts as reached");
+        }
+
+        [Test]
+        public void BudgetReached_FalseForZeroOrNegativeBudget()
+        {
+            // Legacy path is selected by budget==0; the helper must not claim "reached".
+            Assert.IsFalse(LootBudget.BudgetReached(0, 0));
+            Assert.IsFalse(LootBudget.BudgetReached(9999, 0));
+            Assert.IsFalse(LootBudget.BudgetReached(0, -100));
+        }
+
+        [Test]
+        public void ShouldAccept_TrueWhenSumStaysAtOrUnderCeiling()
+        {
+            // Ceiling = 1000.
+            Assert.IsTrue(LootBudget.ShouldAccept(50, 0, 500));
+            Assert.IsTrue(LootBudget.ShouldAccept(200, 700, 500), "700 + 200 = 900 ≤ 1000");
+            Assert.IsTrue(LootBudget.ShouldAccept(100, 900, 500), "exact ceiling is accepted");
+        }
+
+        [Test]
+        public void ShouldAccept_FalseWhenSumWouldExceedCeiling()
+        {
+            // Ceiling = 1000.
+            Assert.IsFalse(LootBudget.ShouldAccept(200, 900, 500), "900 + 200 > 1000");
+            Assert.IsFalse(LootBudget.ShouldAccept(5000, 0, 500), "single huge roll over ceiling");
+        }
+
+        [Test]
+        public void ShouldAccept_TreatsNegativeCandidateAsZero()
+        {
+            Assert.IsTrue(LootBudget.ShouldAccept(-50, 0, 500));
+            Assert.IsTrue(LootBudget.ShouldAccept(-50, 1000, 500),
+                "exact ceiling + negative-clamped-to-zero = still at ceiling, accepted");
+        }
+
+        [Test]
+        public void ShouldAccept_FalseForZeroOrNegativeBudget()
+        {
+            // Legacy path: nothing should be accepted via the budget loop.
+            Assert.IsFalse(LootBudget.ShouldAccept(50, 0, 0));
+            Assert.IsFalse(LootBudget.ShouldAccept(50, 0, -100));
+        }
+    }
+}

--- a/Space Game/Assets/Tests/EditMode/Editor/LootBudgetTests.cs.meta
+++ b/Space Game/Assets/Tests/EditMode/Editor/LootBudgetTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 10751e5ac43d44c4f846072b34b6e1d8


### PR DESCRIPTION
## Summary
- Closes the implementation half of BACKLOG §7: the per-mission loot-budget recommendation.
- Adds `PlanetDefinition.lootValueBudget` (int, default 0).
- New pure helper `LootBudget` (Min=1.2×, Max=2.0×, safety cap=256 rolls).
- `PlanetLootSpawner` branches:
  - **budget == 0** → unchanged `spawnPoints[] × rollsPerSpawnPoint` legacy loop.
  - **budget > 0** → cycles spawn points and rolls from the `LootPool` until cumulative value hits 1.2× the budget; individual rolls that would push past the 2.0× ceiling are skipped.
- No existing `.asset` is migrated — every shipped planet stays on the legacy path until a designer authors a `lootValueBudget`. Called out as the open follow-up in BACKLOG §7.

## Why this shape
- Pure-helper extract (`LootBudget`) lets the budget decision be unit-tested in EditMode without standing up `NetworkManager`. The spawner stays thin — I/O only.
- Backward compat is structural (default 0 = legacy), not a feature flag. No existing tests, scenes, or planet assets had to change.
- Per-crew-size scaling was explicitly skipped per the BACKLOG recommendation (ghost-join exploitable).

## Test plan
- [x] `dotnet build` all asmdef projects clean after Unity csproj regen.
- [x] Headless `Run-UnityTests.ps1 -TestPlatform EditMode` — **173/173** (was 163/163; +10 new `LootBudgetTests` covering Min/Max formulas, zero/negative-budget legacy semantics, ShouldAccept ceiling, BudgetReached floor, negative-candidate clamp).
- [ ] Playtest: author `lootValueBudget` on `Tier1_StarterJunk.asset` (e.g. 300) and confirm budget loop fires + ceiling caps oversize rolls.

## Follow-up (not this PR)
- Author `lootValueBudget` per planet (Starter Junk, Rusty Moon, Violet Giant, tier 3+) — `.asset` edits only, no code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)