### PR TITLE
feat: §9 PlanetHazardSet ScriptableObject (eligibility slice)

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -189,6 +189,8 @@ Grooming questions:
 
 Recommendation: introduce a **`PlanetHazardSet.asset`** ScriptableObject referenced from `PlanetDefinition` declaring spawn rates, eligible hazards, and a ramp curve. Keeps hazard tuning data-driven (matches the SO-first rule). Per-planet flavor unlocks naturally — e.g. "Wraith Halo has anomaly orbs but no monsters; Cobalt Trench has slow monsters but flooding."
 
+**Status 2026-05-19: eligibility slice shipped.** `PlanetHazardSet` SO + `PlanetDefinition.hazardSet` field landed. `AnomalySpawner.TrySpawnOrb` now resolves its prefab pool through `PlanetHazardSet.ResolveAnomalyPrefabs(planet, globalDefault)`: `SuppressAnomalies` → empty (unchanged); `HazardSet` present → that SO's `AnomalyPrefabs` (replaces, not appends, the global); no `HazardSet` → existing global list. Monster prefab array is declared on the SO for data-shape completeness but not yet consumed — monster wiring + spawn-rate + ramp-curve are queued follow-ups. EditMode-validated via `PlanetHazardSetTests`. **Open follow-up: author per-planet `HazardSet` assets** (Wraith Halo = orbs only, Cobalt Trench = no anomalies, etc.) — all `.asset` edits, no code.
+
 ## 10. Dead-player loop
 
 Dead-player carrying is implemented for body recovery, but the surrounding loop is not defined. Decide whether recovered bodies enable revive, count for extraction, provide score, or only avoid leaving players stranded.

--- a/Space Game/Assets/Scripts/Hazards/AnomalySpawner.cs
+++ b/Space Game/Assets/Scripts/Hazards/AnomalySpawner.cs
@@ -43,16 +43,18 @@ namespace FriendSlop.Hazards
 
         private void TrySpawnOrb()
         {
-            if (anomalyPrefabs.Length == 0) return;
-
-            // Per-planet opt-out: PlanetDefinition.SuppressAnomalies is the data-driven
-            // gate for "no anomalies on this planet" - test sandboxes and any future
-            // cozy/cinematic planets flip it on and the global spawner skips them. Per-
-            // scene AnomalySpawner instances (Ice Planet's IceMine spawner, etc.) are
-            // separate components and ignore this check.
+            // Resolve the eligible anomaly pool through PlanetHazardSet so per-planet
+            // SO-driven configuration wins over the global anomalyPrefabs list:
+            //   - PlanetDefinition.SuppressAnomalies      → empty pool (hard suppression).
+            //   - PlanetDefinition.HazardSet present      → that SO's AnomalyPrefabs.
+            //   - otherwise                               → our serialized anomalyPrefabs[].
+            // Per-scene AnomalySpawner instances (Ice Planet's IceMine, etc.) still go
+            // through the same resolver — empty pool means they too stay silent on
+            // suppressed planets, which is the existing semantic.
             var round = RoundManagerRegistry.Current;
             var activePlanet = round != null ? round.CurrentPlanet : null;
-            if (activePlanet != null && activePlanet.SuppressAnomalies) return;
+            var pool = PlanetHazardSet.ResolveAnomalyPrefabs(activePlanet, anomalyPrefabs);
+            if (pool.Count == 0) return;
 
             var liveCount = 0;
             foreach (var active in _activeOrbs)
@@ -65,7 +67,7 @@ namespace FriendSlop.Hazards
             if (world == null) return;
 
             var spawnPos = world.GetSurfacePoint(Random.onUnitSphere, 2f);
-            var prefab = anomalyPrefabs[Random.Range(0, anomalyPrefabs.Length)];
+            var prefab = pool[Random.Range(0, pool.Count)];
             if (prefab == null) return;
 
             // Spawn into the active planet scene with destroyWithScene:true so anomalies

--- a/Space Game/Assets/Scripts/Hazards/PlanetHazardSet.cs
+++ b/Space Game/Assets/Scripts/Hazards/PlanetHazardSet.cs
@@ -1,0 +1,50 @@
+using System;
+using System.Collections.Generic;
+using FriendSlop.Round;
+using UnityEngine;
+
+namespace FriendSlop.Hazards
+{
+    // Per-planet hazard configuration (BACKLOG §9). Lets each PlanetDefinition
+    // declare its eligible hazard prefabs (anomalies, monsters) without
+    // hand-editing the global AnomalySpawner / MonsterSpawner arrays. Monster
+    // consumption is queued — only AnomalySpawner reads this today.
+    //
+    // Resolution rules (centralised in ResolveAnomalyPrefabs so both the
+    // spawner and tests agree):
+    //   - No active planet, or planet has no hazardSet  → spawner falls back
+    //     to its serialized global prefab list.
+    //   - planet.SuppressAnomalies == true             → empty list (hard
+    //     suppression always wins; matches existing semantics).
+    //   - planet.HazardSet present with non-empty anomalies → that list.
+    //   - planet.HazardSet present but empty anomalies → empty list (this
+    //     planet authored "no anomalies" via data).
+    [CreateAssetMenu(menuName = "Friend Slop/Hazards/Planet Hazard Set", fileName = "HazardSet")]
+    public class PlanetHazardSet : ScriptableObject
+    {
+        [Tooltip("Anomaly prefabs eligible to spawn on this planet. Replaces the global " +
+                 "AnomalySpawner anomalyPrefabs list when set. Empty array = no anomalies.")]
+        [SerializeField] private GameObject[] anomalyPrefabs = Array.Empty<GameObject>();
+
+        [Tooltip("Monster prefabs eligible on this planet. Declared here for data-shape " +
+                 "completeness; monster spawning is not yet wired to consume this list — " +
+                 "queued as a follow-up to §9.")]
+        [SerializeField] private GameObject[] monsterPrefabs = Array.Empty<GameObject>();
+
+        public IReadOnlyList<GameObject> AnomalyPrefabs => anomalyPrefabs ?? Array.Empty<GameObject>();
+        public IReadOnlyList<GameObject> MonsterPrefabs => monsterPrefabs ?? Array.Empty<GameObject>();
+
+        // Pure resolver: which anomaly prefabs apply for `planet`? Static so the
+        // decision is unit-testable without standing up an AnomalySpawner.
+        public static IReadOnlyList<GameObject> ResolveAnomalyPrefabs(
+            PlanetDefinition planet,
+            IReadOnlyList<GameObject> globalDefault)
+        {
+            var fallback = globalDefault ?? (IReadOnlyList<GameObject>)Array.Empty<GameObject>();
+            if (planet == null) return fallback;
+            if (planet.SuppressAnomalies) return Array.Empty<GameObject>();
+            if (planet.HazardSet == null) return fallback;
+            return planet.HazardSet.AnomalyPrefabs;
+        }
+    }
+}

--- a/Space Game/Assets/Scripts/Hazards/PlanetHazardSet.cs.meta
+++ b/Space Game/Assets/Scripts/Hazards/PlanetHazardSet.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: e2814efd855c23e4eb81760ccd89f0aa

--- a/Space Game/Assets/Scripts/Round/PlanetDefinition.cs
+++ b/Space Game/Assets/Scripts/Round/PlanetDefinition.cs
@@ -1,3 +1,4 @@
+using FriendSlop.Hazards;
 using FriendSlop.SceneManagement;
 using UnityEngine;
 
@@ -34,6 +35,10 @@ namespace FriendSlop.Round
         // to iterate on procgen without orbs underfoot.
         [Header("Hazards")]
         [SerializeField] private bool suppressAnomalies;
+        [Tooltip("Optional per-planet hazard configuration. When set, the global " +
+                 "AnomalySpawner uses this list's anomalyPrefabs instead of its own. " +
+                 "SuppressAnomalies always wins. See BACKLOG §9.")]
+        [SerializeField] private PlanetHazardSet hazardSet;
 
         // When true, this planet is hidden from the normal tier-progression menus and is
         // only reachable via the host's Test Mode picker. Pair with flatTestWorld for the
@@ -63,6 +68,7 @@ namespace FriendSlop.Round
         // FlatTestWorld implies TestModeOnly; the explicit flag covers test-only planets
         // that aren't the procedural flat world.
         public bool SuppressAnomalies => suppressAnomalies;
+        public PlanetHazardSet HazardSet => hazardSet;
         public bool IsTestModeOnly => testModeOnly || flatTestWorld;
         public bool IsFlatTestWorld => flatTestWorld;
         public TestWorldDisplaySet DisplaySet => displaySet;

--- a/Space Game/Assets/Tests/EditMode/Editor/PlanetHazardSetTests.cs
+++ b/Space Game/Assets/Tests/EditMode/Editor/PlanetHazardSetTests.cs
@@ -1,0 +1,154 @@
+using System.Linq;
+using FriendSlop.Hazards;
+using FriendSlop.Round;
+using NUnit.Framework;
+using UnityEngine;
+
+namespace FriendSlop.Tests.EditMode
+{
+    // Pins the BACKLOG §9 PlanetHazardSet resolver contract. The AnomalySpawner
+    // calls ResolveAnomalyPrefabs(planet, globalDefault) every spawn tick — these
+    // tests freeze the four decision branches (null planet, hard suppress, no
+    // hazard set, hazard set present) so a regression there surfaces here, not in
+    // a playtest where it presents as "anomalies stopped spawning on Wraith Halo".
+    public class PlanetHazardSetTests
+    {
+        // ── Helpers ────────────────────────────────────────────────────────────
+
+        private static GameObject MakePrefab(string name)
+        {
+            // GameObject with no NetworkObject is fine — the resolver only cares
+            // about array identity / count, not what the prefab does.
+            var go = new GameObject(name);
+            return go;
+        }
+
+        private static PlanetHazardSet MakeHazardSet(params GameObject[] anomalyPrefabs)
+        {
+            var set = ScriptableObject.CreateInstance<PlanetHazardSet>();
+            var so  = new UnityEditor.SerializedObject(set);
+            var arr = so.FindProperty("anomalyPrefabs");
+            arr.arraySize = anomalyPrefabs.Length;
+            for (int i = 0; i < anomalyPrefabs.Length; i++)
+                arr.GetArrayElementAtIndex(i).objectReferenceValue = anomalyPrefabs[i];
+            so.ApplyModifiedPropertiesWithoutUndo();
+            return set;
+        }
+
+        private static PlanetDefinition MakePlanet(
+            bool suppressAnomalies = false,
+            PlanetHazardSet hazardSet = null)
+        {
+            var planet = ScriptableObject.CreateInstance<PlanetDefinition>();
+            var so = new UnityEditor.SerializedObject(planet);
+            so.FindProperty("suppressAnomalies").boolValue = suppressAnomalies;
+            so.FindProperty("hazardSet").objectReferenceValue = hazardSet;
+            so.ApplyModifiedPropertiesWithoutUndo();
+            return planet;
+        }
+
+        // ── SO accessors ───────────────────────────────────────────────────────
+
+        [Test]
+        public void AnomalyPrefabs_ReturnsEmptyForFreshInstance()
+        {
+            var set = ScriptableObject.CreateInstance<PlanetHazardSet>();
+            Assert.AreEqual(0, set.AnomalyPrefabs.Count);
+            Assert.AreEqual(0, set.MonsterPrefabs.Count);
+        }
+
+        [Test]
+        public void AnomalyPrefabs_ReturnsAuthoredEntries()
+        {
+            var a = MakePrefab("A");
+            var b = MakePrefab("B");
+            var set = MakeHazardSet(a, b);
+
+            CollectionAssert.AreEqual(new[] { a, b }, set.AnomalyPrefabs.ToList());
+        }
+
+        // ── Resolver ───────────────────────────────────────────────────────────
+
+        [Test]
+        public void Resolve_NullPlanet_ReturnsGlobalDefault()
+        {
+            var globalA = MakePrefab("GlobalA");
+            var globalB = MakePrefab("GlobalB");
+            var global = new[] { globalA, globalB };
+
+            var result = PlanetHazardSet.ResolveAnomalyPrefabs(null, global);
+
+            CollectionAssert.AreEqual(global, result.ToList());
+        }
+
+        [Test]
+        public void Resolve_NullPlanet_NullDefault_ReturnsEmpty()
+        {
+            var result = PlanetHazardSet.ResolveAnomalyPrefabs(null, null);
+
+            Assert.IsNotNull(result, "Resolver must not return null");
+            Assert.AreEqual(0, result.Count);
+        }
+
+        [Test]
+        public void Resolve_SuppressAnomalies_ReturnsEmpty_EvenWhenHazardSetHasEntries()
+        {
+            var setEntry = MakePrefab("InSet");
+            var set = MakeHazardSet(setEntry);
+            var planet = MakePlanet(suppressAnomalies: true, hazardSet: set);
+
+            var globalDefault = new[] { MakePrefab("Global") };
+            var result = PlanetHazardSet.ResolveAnomalyPrefabs(planet, globalDefault);
+
+            Assert.AreEqual(0, result.Count, "Hard suppression must beat the hazard-set override");
+        }
+
+        [Test]
+        public void Resolve_NoHazardSet_FallsBackToGlobalDefault()
+        {
+            var globalA = MakePrefab("GlobalA");
+            var planet = MakePlanet(suppressAnomalies: false, hazardSet: null);
+
+            var result = PlanetHazardSet.ResolveAnomalyPrefabs(planet, new[] { globalA });
+
+            CollectionAssert.AreEqual(new[] { globalA }, result.ToList());
+        }
+
+        [Test]
+        public void Resolve_HazardSetWithEntries_OverridesGlobalDefault()
+        {
+            var setA = MakePrefab("SetA");
+            var setB = MakePrefab("SetB");
+            var set = MakeHazardSet(setA, setB);
+            var planet = MakePlanet(hazardSet: set);
+
+            var globalDefault = new[] { MakePrefab("Global") };
+            var result = PlanetHazardSet.ResolveAnomalyPrefabs(planet, globalDefault);
+
+            CollectionAssert.AreEqual(new[] { setA, setB }, result.ToList(),
+                "Hazard-set entries replace, not append to, the global default");
+        }
+
+        [Test]
+        public void Resolve_HazardSetWithEmptyAnomalies_SuppressesViaData()
+        {
+            var set = MakeHazardSet(); // explicitly empty
+            var planet = MakePlanet(hazardSet: set);
+
+            var globalDefault = new[] { MakePrefab("Global") };
+            var result = PlanetHazardSet.ResolveAnomalyPrefabs(planet, globalDefault);
+
+            Assert.AreEqual(0, result.Count,
+                "Planet authored 'hazardSet with no anomalies' = explicit no-anomalies");
+        }
+
+        [Test]
+        public void PlanetDefinition_HazardSetGetter_RoundTrips()
+        {
+            var set = ScriptableObject.CreateInstance<PlanetHazardSet>();
+            var planet = MakePlanet(hazardSet: set);
+
+            Assert.AreSame(set, planet.HazardSet);
+        }
+    }
+}

--- a/Space Game/Assets/Tests/EditMode/Editor/PlanetHazardSetTests.cs.meta
+++ b/Space Game/Assets/Tests/EditMode/Editor/PlanetHazardSetTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: ac9a97a5181ad3d4da89dba7732e01c8


### PR DESCRIPTION
## Summary
- Closes the **eligibility** half of BACKLOG §9: per-planet hazard configuration as data, not code.
- New `PlanetHazardSet` SO with `anomalyPrefabs[]` + `monsterPrefabs[]`. Monster array is declared but **not yet consumed** — current PR is anomaly-side only, since `AnomalySpawner` is the live consumer.
- New `PlanetDefinition.hazardSet` field.
- New static resolver `PlanetHazardSet.ResolveAnomalyPrefabs(planet, globalDefault)` that centralises the four decision branches:
  | planet state | result |
  |---|---|
  | null | `globalDefault` |
  | `SuppressAnomalies = true` | empty (hard suppression always wins) |
  | `HazardSet == null` | `globalDefault` |
  | `HazardSet` present | that SO's `AnomalyPrefabs` (replaces, not appends to, the global) |
- `AnomalySpawner.TrySpawnOrb` now picks its prefab pool through the resolver — removed the inline `SuppressAnomalies` branch since the resolver folds it in.

## Why this shape
- Static resolver lets the four-way decision be unit-tested without standing up `NetworkManager` / `RoundManager` / a Scene.
- "Empty hazardSet = explicit no-anomalies" is the right semantic for per-planet flavor (Wraith Halo wants orbs, Cobalt Trench wants none).
- Spawn rates + ramp curve from the BACKLOG recommendation are **out of scope here** — current `AnomalySpawner` rates stay global, which gets per-planet *flavor* shipped without dragging in scheduling complexity.

## Test plan
- [x] Headless `Run-UnityTests.ps1 -TestPlatform EditMode` — **172/172** (was 163/163; +9 new `PlanetHazardSetTests`).
- [x] Covered: accessor defaults, all four resolver branches incl. "hazardSet present but empty = data-driven suppress", hard-suppress-beats-override, `HazardSet` getter round-trip.
- [ ] Playtest: author a `PlanetHazardSet.asset` for one planet (e.g. Wraith Halo) and confirm only its anomaly prefabs spawn there.

## Follow-up (not this PR)
- Wire `monsterPrefabs[]` into the monster spawn path (once one exists at the right granularity).
- Per-prefab spawn rates + ramp curve on the SO (BACKLOG §9's full recommendation).
- Author per-planet `HazardSet.asset` for Wraith Halo / Cobalt Trench / Volt Foundry — `.asset` edits only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)