### PR TITLE
data: per-planet lootValueBudget (§7) + HazardSet.asset (§9)

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -4,17 +4,16 @@ This is the current gameplay and implementation backlog, ordered by the work tha
 
 Each open-design section lists the concrete options on the table and a recommended choice. When a decision lands, replace the recommendation with the chosen approach + rationale, and update [docs/architecture.md](docs/architecture.md) if the decision changes architecture. See the **Decision dependencies** appendix at the bottom for which decisions unblock the most downstream work.
 
-## Status overview (2026-05-19)
+## Status overview (2026-05-21)
 
 Section numbers are stable for git-blame continuity; this overview is the "you are here" snapshot. When you change a section's state, update this overview too.
 
 ### Active — agent-doable now
 
-- **§7 Loot economy** — `lootValueBudget` per-mission budget model decided; implement (`PlanetDefinition`, `PlanetLootSpawner`).
-- **§9 Enemy/hazard design** — `PlanetHazardSet.asset` decided; implement (new SO + per-planet wiring on existing spawners).
+- **§9 Enemy/hazard design** — eligibility slice + per-planet `HazardSet.asset` data shipped. Remaining: monster prefab array on `PlanetHazardSet` is declared but not consumed — monster wiring + spawn-rate + ramp-curve queued.
 - **§15e UI polling rewrite** — HUD widget (health/stamina) event-driven slice remains; pairs with §11.
 - **§15f Test backfill** — weapons (`LaserGun`/`BoxingGloves`) lowest-hanging.
-- **§16c Interior tests** — #1 shipped (PR #41). Remaining: #2 `BuildingDefinitionRoomPoolTests` (next), #3 `PlanetLootSpawnerSceneOwnershipTests` (PlayMode), #4 `FurnitureSelectionTests`, #5 `InteriorSceneBootstrapper` PlayMode smoke, #6 `InteriorCatalogTests`.
+- **§16c Interior tests** — #1 shipped (PR #41), #2 shipped (PR #43). Remaining: #3 `PlanetLootSpawnerSceneOwnershipTests` (PlayMode), #4 `FurnitureSelectionTests`, #5 `InteriorSceneBootstrapper` PlayMode smoke, #6 `InteriorCatalogTests`.
 - **§16d Oversized-file splits** — `BlueprintEditorController.cs` (545 lines, editor-only) is the safest first split.
 
 ### Decisions pending — block downstream work
@@ -43,10 +42,13 @@ Section numbers are stable for git-blame continuity; this overview is the "you a
 
 ### Done — retained for context
 
+- **§7** Loot economy — `lootValueBudget` model (PR #44) + per-planet authoring — 2026-05-21.
+- **§9 (partial)** Hazard eligibility slice (PR #45) + per-planet `HazardSet.asset` authoring — 2026-05-21. Monster wiring still queued (see Active).
 - **§15c** Asmdef split D-006 (Core ← Networking/SceneManagement ← Gameplay ← UI ← Editor) — 2026-05-19, PR #40.
 - **§16a** Interiors doc gaps — 2026-05-13.
 - **§16b** Interiors code fixes (4) — 2026-05-15, PR #33.
 - **§16c #1** `BlueprintLayoutBuilderTests` — 2026-05-19, PR #41.
+- **§16c #2** `BuildingDefinitionRoomPoolTests` — 2026-05-19, PR #43.
 - **§17a/b/c** Vendor quarantine + `Assets/ThirdParty/` relocate — 2026-05-18.
 
 ## 1. Planet lifecycle and scene ownership
@@ -200,7 +202,9 @@ Grooming questions:
 
 Recommendation: a **per-mission budget model** with a 120% guaranteed minimum and 200% potential ceiling. Each `PlanetDefinition` declares `quotaTarget` (already exists) plus a new `lootValueBudget`; the spawner rolls until total spawned value is in `[1.2 × quotaTarget, 2.0 × quotaTarget]`. Within budget, items come from a `LootPool.asset` rolled by rarity weights. Do not scale by crew size for v1 — too easy to game by ghost-joining.
 
-**Status 2026-05-19: code-side shipped.** `PlanetDefinition.lootValueBudget` (int, default 0) and a pure `LootBudget` helper (Min=1.2×, Max=2.0×, safety cap = 256 rolls) wire `PlanetLootSpawner` into a budget-driven loop: it cycles through `spawnPoints[]`, rolls until cumulative item value reaches the 1.2× floor, and skips individual rolls that would push past the 2.0× ceiling. `lootValueBudget == 0` keeps the legacy `spawnPoints × rollsPerSpawnPoint` behavior intact for every existing planet asset. EditMode-validated via `LootBudgetTests`. **Open follow-up: author `lootValueBudget` per-planet** (Starter Junk, Rusty Moon, Violet Giant, tier 3+) so the budget loop actually activates — currently every shipped `.asset` is at 0 (legacy).
+**Status 2026-05-19: code-side shipped.** `PlanetDefinition.lootValueBudget` (int, default 0) and a pure `LootBudget` helper (Min=1.2×, Max=2.0×, safety cap = 256 rolls) wire `PlanetLootSpawner` into a budget-driven loop: it cycles through `spawnPoints[]`, rolls until cumulative item value reaches the 1.2× floor, and skips individual rolls that would push past the 2.0× ceiling. `lootValueBudget == 0` keeps the legacy `spawnPoints × rollsPerSpawnPoint` behavior intact for every existing planet asset. EditMode-validated via `LootBudgetTests`.
+
+**Status 2026-05-21: §7 CLOSED — per-planet budgets authored.** All seven shipped planet definitions now declare a `lootValueBudget` matched to their objective/pacing: Starter Junk 400 (intro slack above the 500 default quota), Rusty Moon 300 (matches Smash-and-Grab's 250 quota with headroom), Cobalt Trench 500 (long shift / big payday), Volt Foundry 300 (tight cycle), Wraith Halo 200 (survival objective de-emphasises loot), Violet Giant 250, Ice Planet 350. `Tier4_HillsAndValleys` and `TestWorld_Flat` intentionally left at 0 (legacy mode — they're test-mode sandboxes). The budget loop is now live for every catalog planet a player reaches through normal tier progression.
 
 ## 8. Combat and item rules
 
@@ -236,7 +240,9 @@ Grooming questions:
 
 Recommendation: introduce a **`PlanetHazardSet.asset`** ScriptableObject referenced from `PlanetDefinition` declaring spawn rates, eligible hazards, and a ramp curve. Keeps hazard tuning data-driven (matches the SO-first rule). Per-planet flavor unlocks naturally — e.g. "Wraith Halo has anomaly orbs but no monsters; Cobalt Trench has slow monsters but flooding."
 
-**Status 2026-05-19: eligibility slice shipped.** `PlanetHazardSet` SO + `PlanetDefinition.hazardSet` field landed. `AnomalySpawner.TrySpawnOrb` now resolves its prefab pool through `PlanetHazardSet.ResolveAnomalyPrefabs(planet, globalDefault)`: `SuppressAnomalies` → empty (unchanged); `HazardSet` present → that SO's `AnomalyPrefabs` (replaces, not appends, the global); no `HazardSet` → existing global list. Monster prefab array is declared on the SO for data-shape completeness but not yet consumed — monster wiring + spawn-rate + ramp-curve are queued follow-ups. EditMode-validated via `PlanetHazardSetTests`. **Open follow-up: author per-planet `HazardSet` assets** (Wraith Halo = orbs only, Cobalt Trench = no anomalies, etc.) — all `.asset` edits, no code.
+**Status 2026-05-19: eligibility slice shipped.** `PlanetHazardSet` SO + `PlanetDefinition.hazardSet` field landed. `AnomalySpawner.TrySpawnOrb` now resolves its prefab pool through `PlanetHazardSet.ResolveAnomalyPrefabs(planet, globalDefault)`: `SuppressAnomalies` → empty (unchanged); `HazardSet` present → that SO's `AnomalyPrefabs` (replaces, not appends, the global); no `HazardSet` → existing global list. Monster prefab array is declared on the SO for data-shape completeness but not yet consumed — monster wiring + spawn-rate + ramp-curve are queued follow-ups. EditMode-validated via `PlanetHazardSetTests`.
+
+**Status 2026-05-21: per-planet `HazardSet.asset`s authored under `Assets/Hazards/HazardSets/`.** Six SOs ship: `HazardSet_VanillaOrbs` (all 5 generic orbs — Starter Junk, Rusty Moon), `HazardSet_NoAnomalies` (empty pool — Cobalt Trench's "loot scarcity + time pressure" framing), `HazardSet_Industrial` (Electric only — Volt Foundry thematic), `HazardSet_Haunted` (Wandering + Hostile — Wraith Halo's eerie survival), `HazardSet_Tier3Escalation` (Hostile + Electric — Violet Giant's aggression mix), `HazardSet_Ice` (IceMine + Electric — preserves the scene-local IceMine spawn since `ResolveAnomalyPrefabs` consolidates all spawners on a planet through one resolver). Tier 4 sandbox and Flat Test World left unmodified (already `SuppressAnomalies:1` / `flatTestWorld:1`). **Remaining §9 work: monster prefab array on `PlanetHazardSet` declared but not yet consumed** — `RoamingMonster` spawning still uses the bootstrapper's per-session list, not the SO. Spawn-rate + ramp-curve are also still queued (today every planet uses the same global `minSpawnInterval`/`maxSpawnInterval` on `AnomalySpawner`).
 
 ## 10. Dead-player loop
 

--- a/Space Game/Assets/Hazards.meta
+++ b/Space Game/Assets/Hazards.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 41b0a65c63f54abfba286675497c025b
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Space Game/Assets/Hazards/HazardSets.meta
+++ b/Space Game/Assets/Hazards/HazardSets.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a3e3d354a01843d7b312c003585615d7
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Space Game/Assets/Hazards/HazardSets/HazardSet_Haunted.asset
+++ b/Space Game/Assets/Hazards/HazardSets/HazardSet_Haunted.asset
@@ -1,0 +1,21 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e2814efd855c23e4eb81760ccd89f0aa, type: 3}
+  m_Name: HazardSet_Haunted
+  m_EditorClassIdentifier: FriendSlop.Gameplay::FriendSlop.Hazards.PlanetHazardSet
+  # Wandering + Hostile only — spectral threats. Used for Wraith Halo's
+  # "haunted ring world" framing where the survival objective is about
+  # dodging eerie presences rather than fighting/avoiding the full bestiary.
+  anomalyPrefabs:
+  - {fileID: 9876543298765432, guid: ff6677889900aa11bb22cc33dd44ee55, type: 3}
+  - {fileID: 1111111199999999, guid: dd44ee55ff6677889900aa11bb22cc33, type: 3}
+  monsterPrefabs: []

--- a/Space Game/Assets/Hazards/HazardSets/HazardSet_Haunted.asset.meta
+++ b/Space Game/Assets/Hazards/HazardSets/HazardSet_Haunted.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 12b922f9166f4b27b78d77ac62911844
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Space Game/Assets/Hazards/HazardSets/HazardSet_Ice.asset
+++ b/Space Game/Assets/Hazards/HazardSets/HazardSet_Ice.asset
@@ -1,0 +1,24 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e2814efd855c23e4eb81760ccd89f0aa, type: 3}
+  m_Name: HazardSet_Ice
+  m_EditorClassIdentifier: FriendSlop.Gameplay::FriendSlop.Hazards.PlanetHazardSet
+  # IceMine + ElectricOrb. The IcePlanet scene already has a scene-local
+  # AnomalySpawner pointing at IceMine, but ResolveAnomalyPrefabs
+  # consolidates ALL spawners on this planet (per-scene + global bootstrap)
+  # through PlanetHazardSet — so we must include IceMine here to preserve
+  # the existing per-scene behavior, then layer ElectricOrb for thematic
+  # variety (arc-discharge + cracked-ice mines).
+  anomalyPrefabs:
+  - {fileID: 9090909099999999, guid: e2f3a4b5c6d70819203a4b5c6d7e8f12, type: 3}
+  - {fileID: 2211223344556677, guid: aabbccddeeff00112233445566778899, type: 3}
+  monsterPrefabs: []

--- a/Space Game/Assets/Hazards/HazardSets/HazardSet_Ice.asset.meta
+++ b/Space Game/Assets/Hazards/HazardSets/HazardSet_Ice.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e2ca30efd0bf456db074324a3c90926e
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Space Game/Assets/Hazards/HazardSets/HazardSet_Industrial.asset
+++ b/Space Game/Assets/Hazards/HazardSets/HazardSet_Industrial.asset
@@ -1,0 +1,19 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e2814efd855c23e4eb81760ccd89f0aa, type: 3}
+  m_Name: HazardSet_Industrial
+  m_EditorClassIdentifier: FriendSlop.Gameplay::FriendSlop.Hazards.PlanetHazardSet
+  # Electric orbs only. Thematic for Volt Foundry — the industrial moon's
+  # ambient menace is arc-discharge, not biological/spectral.
+  anomalyPrefabs:
+  - {fileID: 2211223344556677, guid: aabbccddeeff00112233445566778899, type: 3}
+  monsterPrefabs: []

--- a/Space Game/Assets/Hazards/HazardSets/HazardSet_Industrial.asset.meta
+++ b/Space Game/Assets/Hazards/HazardSets/HazardSet_Industrial.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5fdbf1fb64254e88bd064766127cca62
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Space Game/Assets/Hazards/HazardSets/HazardSet_NoAnomalies.asset
+++ b/Space Game/Assets/Hazards/HazardSets/HazardSet_NoAnomalies.asset
@@ -1,0 +1,20 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e2814efd855c23e4eb81760ccd89f0aa, type: 3}
+  m_Name: HazardSet_NoAnomalies
+  m_EditorClassIdentifier: FriendSlop.Gameplay::FriendSlop.Hazards.PlanetHazardSet
+  # Explicit "no anomalies" via empty list (different from SuppressAnomalies:
+  # SuppressAnomalies is a hard override that wins over everything; an empty
+  # HazardSet just says "this planet's pool is empty"). Used for Cobalt Trench
+  # where the design is loot scarcity + time pressure, not anomaly chaos.
+  anomalyPrefabs: []
+  monsterPrefabs: []

--- a/Space Game/Assets/Hazards/HazardSets/HazardSet_NoAnomalies.asset.meta
+++ b/Space Game/Assets/Hazards/HazardSets/HazardSet_NoAnomalies.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 26d38f9e563c43a9a862604538691031
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Space Game/Assets/Hazards/HazardSets/HazardSet_Tier3Escalation.asset
+++ b/Space Game/Assets/Hazards/HazardSets/HazardSet_Tier3Escalation.asset
@@ -1,0 +1,21 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e2814efd855c23e4eb81760ccd89f0aa, type: 3}
+  m_Name: HazardSet_Tier3Escalation
+  m_EditorClassIdentifier: FriendSlop.Gameplay::FriendSlop.Hazards.PlanetHazardSet
+  # Hostile + Electric. Tier 3 escalation flavor — focus on the
+  # high-aggression subset. Used for Violet Giant's "hold the pad"
+  # survival pressure.
+  anomalyPrefabs:
+  - {fileID: 1111111199999999, guid: dd44ee55ff6677889900aa11bb22cc33, type: 3}
+  - {fileID: 2211223344556677, guid: aabbccddeeff00112233445566778899, type: 3}
+  monsterPrefabs: []

--- a/Space Game/Assets/Hazards/HazardSets/HazardSet_Tier3Escalation.asset.meta
+++ b/Space Game/Assets/Hazards/HazardSets/HazardSet_Tier3Escalation.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 71e0ec86eb824b18ac669bcdfe6105c7
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Space Game/Assets/Hazards/HazardSets/HazardSet_VanillaOrbs.asset
+++ b/Space Game/Assets/Hazards/HazardSets/HazardSet_VanillaOrbs.asset
@@ -1,0 +1,23 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e2814efd855c23e4eb81760ccd89f0aa, type: 3}
+  m_Name: HazardSet_VanillaOrbs
+  m_EditorClassIdentifier: FriendSlop.Gameplay::FriendSlop.Hazards.PlanetHazardSet
+  # Full anomaly variety. Default for early-tier planets so players see the
+  # whole bestiary before bias kicks in (Starter Junk, Rusty Moon).
+  anomalyPrefabs:
+  - {fileID: 1111111122222222, guid: cc33dd44ee55ff6677889900aa11bb22, type: 3}
+  - {fileID: 1111111199999999, guid: dd44ee55ff6677889900aa11bb22cc33, type: 3}
+  - {fileID: 1234567812345678, guid: ee55ff6677889900aa11bb22cc33dd44, type: 3}
+  - {fileID: 9876543298765432, guid: ff6677889900aa11bb22cc33dd44ee55, type: 3}
+  - {fileID: 2211223344556677, guid: aabbccddeeff00112233445566778899, type: 3}
+  monsterPrefabs: []

--- a/Space Game/Assets/Hazards/HazardSets/HazardSet_VanillaOrbs.asset.meta
+++ b/Space Game/Assets/Hazards/HazardSets/HazardSet_VanillaOrbs.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5683d816d53546ce81ad974ab98dbb43
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Space Game/Assets/Planets/Tier1_StarterJunk.asset
+++ b/Space Game/Assets/Planets/Tier1_StarterJunk.asset
@@ -18,7 +18,10 @@ MonoBehaviour:
   tier: 1
   quotaOverride: 0
   roundLengthOverride: 0
+  lootValueBudget: 400
   objective: {fileID: 0}
   skyTint: {r: 1, g: 1, b: 1, a: 1}
   previewIcon: {fileID: 0}
   planetScene: {fileID: 11400000, guid: c4d5e6f78901a2b3c4d5e6f789012345, type: 2}
+  suppressAnomalies: 0
+  hazardSet: {fileID: 11400000, guid: 5683d816d53546ce81ad974ab98dbb43, type: 2}

--- a/Space Game/Assets/Planets/Tier2_DeepHaul.asset
+++ b/Space Game/Assets/Planets/Tier2_DeepHaul.asset
@@ -18,7 +18,10 @@ MonoBehaviour:
   tier: 2
   quotaOverride: 0
   roundLengthOverride: 360
+  lootValueBudget: 500
   objective: {fileID: 11400000, guid: 2d5a8f3e9c7b1d4a6e9c3f7b2d5a8e1c, type: 2}
   skyTint: {r: 1, g: 1, b: 1, a: 1}
   previewIcon: {fileID: 0}
   planetScene: {fileID: 11400000, guid: f4a5b6c7d8e90123456789abcdef0a04, type: 2}
+  suppressAnomalies: 0
+  hazardSet: {fileID: 11400000, guid: 26d38f9e563c43a9a862604538691031, type: 2}

--- a/Space Game/Assets/Planets/Tier2_GhostShift.asset
+++ b/Space Game/Assets/Planets/Tier2_GhostShift.asset
@@ -18,7 +18,10 @@ MonoBehaviour:
   tier: 2
   quotaOverride: 0
   roundLengthOverride: 0
+  lootValueBudget: 200
   objective: {fileID: 11400000, guid: 6c9b2f5e8a1d4c7b3e6a9d2f5c8b1e4a, type: 2}
   skyTint: {r: 1, g: 1, b: 1, a: 1}
   previewIcon: {fileID: 0}
   planetScene: {fileID: 11400000, guid: a5b6c7d8e9f01234567890abcdef0b05, type: 2}
+  suppressAnomalies: 0
+  hazardSet: {fileID: 11400000, guid: 12b922f9166f4b27b78d77ac62911844, type: 2}

--- a/Space Game/Assets/Planets/Tier2_QuickStrike.asset
+++ b/Space Game/Assets/Planets/Tier2_QuickStrike.asset
@@ -18,7 +18,10 @@ MonoBehaviour:
   tier: 2
   quotaOverride: 0
   roundLengthOverride: 150
+  lootValueBudget: 300
   objective: {fileID: 11400000, guid: 4f8a9d2e1c6b7f3a8e5d2c9b4f7e1a6d, type: 2}
   skyTint: {r: 1, g: 1, b: 1, a: 1}
   previewIcon: {fileID: 0}
   planetScene: {fileID: 11400000, guid: b6c7d8e9f0a12345678901abcdef0c06, type: 2}
+  suppressAnomalies: 0
+  hazardSet: {fileID: 11400000, guid: 5fdbf1fb64254e88bd064766127cca62, type: 2}

--- a/Space Game/Assets/Planets/Tier2_RustyMoon.asset
+++ b/Space Game/Assets/Planets/Tier2_RustyMoon.asset
@@ -17,7 +17,10 @@ MonoBehaviour:
   tier: 2
   quotaOverride: 0
   roundLengthOverride: 240
+  lootValueBudget: 300
   objective: {fileID: 11400000, guid: 530dba5b2d61e2d40bdf7e3170dad107, type: 2}
   skyTint: {r: 1, g: 1, b: 1, a: 1}
   previewIcon: {fileID: 0}
   planetScene: {fileID: 11400000, guid: a4b5c6d7e8f90123456789abcdef0123, type: 2}
+  suppressAnomalies: 0
+  hazardSet: {fileID: 11400000, guid: 5683d816d53546ce81ad974ab98dbb43, type: 2}

--- a/Space Game/Assets/Planets/Tier3_IcePlanet.asset
+++ b/Space Game/Assets/Planets/Tier3_IcePlanet.asset
@@ -18,7 +18,10 @@ MonoBehaviour:
   tier: 3
   quotaOverride: 0
   roundLengthOverride: 180
+  lootValueBudget: 350
   objective: {fileID: 11400000, guid: 2a773247d0b5f4b499686dd9e972a40a, type: 2}
   skyTint: {r: 0.78, g: 0.9, b: 1, a: 1}
   previewIcon: {fileID: 0}
   planetScene: {fileID: 11400000, guid: c9d0e1f2a3b4567890124abcdef1c090, type: 2}
+  suppressAnomalies: 0
+  hazardSet: {fileID: 11400000, guid: e2ca30efd0bf456db074324a3c90926e, type: 2}

--- a/Space Game/Assets/Planets/Tier3_VioletGiant.asset
+++ b/Space Game/Assets/Planets/Tier3_VioletGiant.asset
@@ -18,7 +18,10 @@ MonoBehaviour:
   tier: 3
   quotaOverride: 0
   roundLengthOverride: 180
+  lootValueBudget: 250
   objective: {fileID: 11400000, guid: 2a773247d0b5f4b499686dd9e972a40a, type: 2}
   skyTint: {r: 1, g: 1, b: 1, a: 1}
   previewIcon: {fileID: 0}
   planetScene: {fileID: 11400000, guid: b6d140776aca4a93b53db3f79eb77d0d, type: 2}
+  suppressAnomalies: 0
+  hazardSet: {fileID: 11400000, guid: 71e0ec86eb824b18ac669bcdfe6105c7, type: 2}


### PR DESCRIPTION
Activates the loot-budget loop (PR #44) and hazard eligibility resolver (PR #45) on every catalog planet a player reaches through normal tier progression. **Pure ScriptableObject + YAML data; no code touched.**

## §7 — Per-planet `lootValueBudget`

The budget loop in `PlanetLootSpawner.SpawnByBudget` only activates when a planet declares a non-zero `lootValueBudget`. Until this PR, every shipped planet was at `0` (legacy `rollsPerSpawnPoint` mode). Authored values:

| Planet | Budget | Reasoning |
|---|---:|---|
| Starter Junk | 400 | Intro slack above the 500 default quota |
| Rusty Moon | 300 | Matches Smash-and-Grab quota 250 with headroom |
| Cobalt Trench | 500 | "Long shift, big payday" framing |
| Volt Foundry | 300 | Tight cycle |
| Wraith Halo | 200 | Survival objective de-emphasises loot |
| Violet Giant | 250 | Tier 3 hold-the-pad |
| Ice Planet | 350 | Tier 3 scale |

`Tier4_HillsAndValleys` and `TestWorld_Flat` intentionally left at `0` — both are test-mode sandboxes the host iterates on; legacy mode is the right behavior there.

With `LootBudget.Min=1.2×` / `LootBudget.Max=2.0×`, this gives each planet a guaranteed-minimum loot floor of 1.2× the budget and a ceiling of 2.0×, so e.g. Cobalt Trench guarantees ≥$600 and tops out at $1000 worth of items per mission.

## §9 — Per-planet `PlanetHazardSet.asset`

Six SOs under `Assets/Hazards/HazardSets/` thematically-flavored per planet:

| HazardSet | Contents | Planets |
|---|---|---|
| `HazardSet_VanillaOrbs` | All 5 generic orbs | Starter Junk, Rusty Moon |
| `HazardSet_NoAnomalies` | Empty pool | Cobalt Trench (loot scarcity, no chaos) |
| `HazardSet_Industrial` | Electric only | Volt Foundry (arc-discharge thematic) |
| `HazardSet_Haunted` | Wandering + Hostile | Wraith Halo (eerie spectral threats) |
| `HazardSet_Tier3Escalation` | Hostile + Electric | Violet Giant (aggressive subset) |
| `HazardSet_Ice` | IceMine + Electric | Ice Planet (see note below) |

**Ice Planet caveat:** `PlanetHazardSet.ResolveAnomalyPrefabs` consolidates **every** AnomalySpawner on the active planet through one SO — including the scene-local `IceMine` spawner already living in `Planet_IcePlanet.unity`. If `HazardSet_Ice` had only Electric (or were empty), the IceMine would silently stop spawning. Including the IceMine GUID preserves the existing per-scene behavior.

## Out of scope (intentionally)

- **Monster wiring.** `PlanetHazardSet.MonsterPrefabs` is declared as an array but not consumed yet — `RoamingMonster` still uses the bootstrapper's per-session list. Authoring monster pools per planet is queued in BACKLOG §9.
- **Spawn-rate + ramp-curve.** Every planet currently uses the same global `minSpawnInterval`/`maxSpawnInterval` on `AnomalySpawner`. Per-planet pacing is queued in BACKLOG §9.

## Validation

- `FriendSlop.Core` builds clean (`dotnet build`).
- `FriendSlop.Runtime.csproj` on disk has stale pre-§15c paths (bootstrap-relocation regen pending on next Unity open) — unaffected by this data-only PR.
- All `.meta` GUIDs freshly generated via `[guid]::NewGuid()`; no GUID collisions.
- Asset references use the existing global `AnomalySpawner.anomalyPrefabs` list from `FriendSlopPrototype.unity` as the prefab source of truth (FriendlyOrb / HostileOrb / NeutralOrb / WanderingOrb / ElectricOrb) plus the IceMine GUID from `Planet_IcePlanet.unity`.

## What this enables for playtest

- Each planet now has a meaningfully different anomaly flavor instead of every planet drawing from the same global pool.
- Loot density now scales per-planet instead of being uniform; Cobalt Trench actually feels like a haul, Wraith Halo feels like a thin-pickings survival.
- Closes BACKLOG §7 entirely and the data-authoring portion of §9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
