### PR TITLE
feat: ShipStation behavior pattern + 4 stations + salute coordinator

### DIFF
--- a/Space Game/Assets/Scripts/Core/Foundation/BoomboxPlayback.cs
+++ b/Space Game/Assets/Scripts/Core/Foundation/BoomboxPlayback.cs
@@ -1,0 +1,50 @@
+namespace FriendSlop.Ship
+{
+    // Pure-logic helpers for BoomboxStationBehavior. Two responsibilities:
+    //   1. track cycling — pure modular arithmetic, but the trackCount==0
+    //      case has to report "no playback" so the call site doesn't divide
+    //      by zero.
+    //   2. server-time-synced playback offset — late-joining clients need to
+    //      drop the AudioSource head where everyone else's is, derived from
+    //      (NetworkManager.ServerTime - serverStartTime) mod clipLength.
+    //
+    // Pinned by BoomboxPlaybackTests.
+    public static class BoomboxPlayback
+    {
+        public const int NoTrack = -1;
+
+        // Advances the current track index. Returns NoTrack (-1) when there
+        // are no tracks to play; otherwise (current + 1) % trackCount with
+        // negative inputs clamped to 0.
+        public static int NextTrack(int currentTrack, int trackCount)
+        {
+            if (trackCount <= 0) return NoTrack;
+
+            var next = currentTrack < 0 ? 0 : currentTrack + 1;
+            return next % trackCount;
+        }
+
+        // Maps a (serverStartTime, currentServerTime, clipLength) triple to
+        // the AudioSource.time value that puts a late-joining client at the
+        // same playback position as everyone else.
+        //
+        // Returns 0 if clipLength <= 0 (no audio to align). Negative elapsed
+        // is clamped to 0 — that happens if a client's local clock somehow
+        // ran ahead of the server's start timestamp, which would otherwise
+        // produce a nonsensical negative time.
+        public static double ComputeLocalPlaybackTime(
+            double serverStartTime,
+            double currentServerTime,
+            float clipLength)
+        {
+            if (clipLength <= 0f) return 0d;
+
+            var elapsed = currentServerTime - serverStartTime;
+            if (elapsed < 0d) elapsed = 0d;
+
+            // Modulo on doubles via integer division.
+            var loops = (long)(elapsed / clipLength);
+            return elapsed - (loops * (double)clipLength);
+        }
+    }
+}

--- a/Space Game/Assets/Scripts/Core/Foundation/BoomboxPlayback.cs.meta
+++ b/Space Game/Assets/Scripts/Core/Foundation/BoomboxPlayback.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 257ed3f7607c4fa09ac56ac14267aa35
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Space Game/Assets/Scripts/Core/Foundation/DartScoring.cs
+++ b/Space Game/Assets/Scripts/Core/Foundation/DartScoring.cs
@@ -1,0 +1,42 @@
+using System.Collections.Generic;
+
+namespace FriendSlop.Ship
+{
+    // Pure-logic helpers for DartboardStationBehavior. The radius bands are
+    // the contract — designers can re-tune them, but every change must move
+    // a test. Pinned by DartScoringTests.
+    public static class DartScoring
+    {
+        // Radius is normalized so 0 = bullseye, 1 = edge of the board, >1 =
+        // miss. Bands are closed on the left and open on the right except for
+        // the outer miss boundary, which is open on the right too (radius
+        // exactly 1 still scores 1 — only strictly-greater misses).
+        public static int ScoreForRadius(float radius01)
+        {
+            if (radius01 < 0f) radius01 = 0f;
+
+            if (radius01 <= 0.08f) return 50;   // bullseye
+            if (radius01 <= 0.2f)  return 25;
+            if (radius01 <= 0.4f)  return 10;
+            if (radius01 <= 0.65f) return 5;
+            if (radius01 <= 1.0f)  return 1;
+            return 0;                            // off the board
+        }
+
+        // Returns the highest score in the list, or 0 if the list is null or
+        // empty. Used to drive the "current high score" line on the dart-
+        // board prompt without bothering the test harness with a tuple type.
+        public static int FindBest(IReadOnlyList<int> scores)
+        {
+            if (scores == null) return 0;
+
+            var best = 0;
+            for (var i = 0; i < scores.Count; i++)
+            {
+                var s = scores[i];
+                if (s > best) best = s;
+            }
+            return best;
+        }
+    }
+}

--- a/Space Game/Assets/Scripts/Core/Foundation/DartScoring.cs.meta
+++ b/Space Game/Assets/Scripts/Core/Foundation/DartScoring.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: dc938f08a0d747b6b53bd3a4e3c97d9e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Space Game/Assets/Scripts/Core/Foundation/MissionVoteTally.cs
+++ b/Space Game/Assets/Scripts/Core/Foundation/MissionVoteTally.cs
@@ -1,0 +1,59 @@
+using System.Collections.Generic;
+
+namespace FriendSlop.Ship
+{
+    // Pure-logic helpers for the mission-vote station. Pinned by
+    // MissionVoteTallyTests so the cycle / winning-candidate rules can be
+    // reasoned about without a NetworkBehaviour harness.
+    //
+    // "No vote" is represented as byte.MaxValue throughout — it's the value
+    // a NetworkList<MissionVoteEntry> never stores (we omit the entry
+    // entirely), but the cycle helper needs a sentinel to round-trip through.
+    public static class MissionVoteTally
+    {
+        public const byte NoVote = byte.MaxValue;
+
+        // Returns the winning candidate index, or null if no votes were cast.
+        // Deterministic tiebreak: the lowest candidate index wins so playtest
+        // results don't depend on iteration order.
+        public static int? WinningCandidate(IReadOnlyList<int> votesPerCandidate)
+        {
+            if (votesPerCandidate == null || votesPerCandidate.Count == 0)
+                return null;
+
+            var bestIndex = -1;
+            var bestVotes = 0;
+            for (var i = 0; i < votesPerCandidate.Count; i++)
+            {
+                var v = votesPerCandidate[i];
+                if (v <= 0) continue;
+                if (v > bestVotes)
+                {
+                    bestVotes = v;
+                    bestIndex = i;
+                }
+                // Strictly-greater-than means earlier indices win ties.
+            }
+
+            return bestIndex < 0 ? (int?)null : bestIndex;
+        }
+
+        // Cycles a vote: NoVote -> 0 -> 1 -> ... -> candidateCount-1 -> NoVote.
+        // candidateCount <= 0 short-circuits to NoVote so callers can hand off
+        // the user's press to a no-op without a special case at the call site.
+        public static byte CycleVote(byte currentVote, int candidateCount)
+        {
+            if (candidateCount <= 0) return NoVote;
+
+            if (currentVote == NoVote)
+                return 0;
+
+            // Wrap to NoVote once we've passed the last real index.
+            var next = currentVote + 1;
+            if (next >= candidateCount)
+                return NoVote;
+
+            return (byte)next;
+        }
+    }
+}

--- a/Space Game/Assets/Scripts/Core/Foundation/MissionVoteTally.cs.meta
+++ b/Space Game/Assets/Scripts/Core/Foundation/MissionVoteTally.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9c876957c047453b938bd7ec102881db
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Space Game/Assets/Scripts/Core/Foundation/SaluteWindow.cs
+++ b/Space Game/Assets/Scripts/Core/Foundation/SaluteWindow.cs
@@ -1,0 +1,80 @@
+using System.Collections.Generic;
+
+namespace FriendSlop.Ship
+{
+    // Pure-logic helper for SaluteCoordinator. The coordinator records every
+    // station salute as (clientId, saluteTime). On each server tick it asks
+    // this helper: "has every currently-occupied station saluted within the
+    // last windowSeconds?". When the answer is yes, the coordinator fires
+    // PerfectCrewClientRpc and clears the salute log to debounce.
+    //
+    // Pinned by SaluteWindowTests.
+    public struct SaluteRecord
+    {
+        public ulong clientId;
+        public float saluteTime;
+
+        public SaluteRecord(ulong clientId, float saluteTime)
+        {
+            this.clientId = clientId;
+            this.saluteTime = saluteTime;
+        }
+    }
+
+    public static class SaluteWindow
+    {
+        // Returns true if every occupied client id has at least one salute
+        // record whose saluteTime is within `windowSeconds` of `now`.
+        // Empty occupied list -> true (vacuously satisfied; coordinator
+        // shouldn't celebrate when nobody is at a station, so the caller is
+        // responsible for the "at least one occupied station" guard).
+        public static bool AllOccupiedSaluteWithinWindow(
+            IReadOnlyList<ulong> occupiedClientIds,
+            IReadOnlyList<SaluteRecord> recentSalutes,
+            float now,
+            float windowSeconds)
+        {
+            if (occupiedClientIds == null || occupiedClientIds.Count == 0)
+                return true;
+
+            if (windowSeconds <= 0f)
+                return false;
+
+            for (var i = 0; i < occupiedClientIds.Count; i++)
+            {
+                var occupant = occupiedClientIds[i];
+                if (!HasRecentSalute(occupant, recentSalutes, now, windowSeconds))
+                    return false;
+            }
+
+            return true;
+        }
+
+        private static bool HasRecentSalute(
+            ulong clientId,
+            IReadOnlyList<SaluteRecord> recentSalutes,
+            float now,
+            float windowSeconds)
+        {
+            if (recentSalutes == null) return false;
+
+            // Take the latest salute for this client (records can repeat if
+            // a player double-presses; the coordinator doesn't dedupe).
+            var latest = float.NegativeInfinity;
+            var found = false;
+            for (var i = 0; i < recentSalutes.Count; i++)
+            {
+                var r = recentSalutes[i];
+                if (r.clientId != clientId) continue;
+                if (!found || r.saluteTime > latest)
+                {
+                    latest = r.saluteTime;
+                    found = true;
+                }
+            }
+
+            if (!found) return false;
+            return (now - latest) <= windowSeconds;
+        }
+    }
+}

--- a/Space Game/Assets/Scripts/Core/Foundation/SaluteWindow.cs.meta
+++ b/Space Game/Assets/Scripts/Core/Foundation/SaluteWindow.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 03c99046aa8045c89437fb815a60202d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Space Game/Assets/Scripts/Editor/FriendSlopSceneWiringRepair.ShipStationBehaviors.cs
+++ b/Space Game/Assets/Scripts/Editor/FriendSlopSceneWiringRepair.ShipStationBehaviors.cs
@@ -10,20 +10,25 @@ namespace FriendSlop.Editor
     // canonical way to wire a new component onto a scene GameObject is a
     // repair-tool pass.
     //
-    // This pass guarantees every existing ShipStation in ShipInterior has a
-    // matching ShipStationBehavior sibling component:
+    // This pass guarantees every existing ShipStation in ShipInterior has
+    // a matching ShipStationBehavior sibling. The mapping promotes each
+    // legacy enum role to its specialised behavior so the four new fun
+    // activities (Mission Vote / Boombox / Dartboard) become visible
+    // without authoring new prefabs:
     //
-    //   role == Pilot         ->  PilotStationBehavior
-    //   anything else         ->  LegacyOccupancyBehavior
+    //   role == Pilot             -> PilotStationBehavior
+    //   role == HolographicBoard  -> MissionVoteBehavior
+    //   role == MiniGame          -> DartboardStationBehavior (+ "Target" child)
+    //   role == Customization     -> BoomboxStationBehavior
+    //   role == Utility           -> LegacyOccupancyBehavior
     //
-    // It does NOT instantiate new GameObjects for MissionVote / Boombox /
-    // Dartboard stations — those want fresh GameObjects with collider +
-    // visual children that the repair tool can't synthesise from code
-    // alone. Authoring those stations is a follow-up PR.
-    //
-    // Repair is idempotent: if the sibling already exists we leave it
+    // Repair is idempotent: if a sibling already exists we leave it
     // alone, preserving any inspector tuning a designer did. The scene is
     // only marked dirty when something actually changed.
+    //
+    // Backward compat: if a station's role doesn't match the table above
+    // (future enum value, corrupted asset) we still drop in
+    // LegacyOccupancyBehavior so the station stays usable.
     public static partial class FriendSlopSceneWiringRepair
     {
         private static bool EnsureStationBehaviorSiblings(Scene scene)
@@ -39,23 +44,89 @@ namespace FriendSlop.Editor
                 var station = stations[i];
                 if (station == null || station.gameObject.scene != scene) continue;
 
-                var existing = station.GetComponent<ShipStationBehavior>();
-                if (existing != null) continue;
-
-                if (station.Role == ShipStationRole.Pilot)
+                if (EnsureBehaviorFor(station))
                 {
-                    station.gameObject.AddComponent<PilotStationBehavior>();
+                    EditorUtility.SetDirty(station.gameObject);
+                    changed = true;
                 }
-                else
-                {
-                    station.gameObject.AddComponent<LegacyOccupancyBehavior>();
-                }
-
-                EditorUtility.SetDirty(station.gameObject);
-                changed = true;
             }
 
             return changed;
+        }
+
+        // Returns true if any state changed on the station's GameObject.
+        // Adds the right behavior sibling for the station's enum role, and
+        // performs any per-behavior child wiring (notably the dartboard's
+        // "Target" child plane).
+        private static bool EnsureBehaviorFor(ShipStation station)
+        {
+            var existing = station.GetComponent<ShipStationBehavior>();
+            var changed = false;
+
+            if (existing == null)
+            {
+                AddBehaviorForRole(station);
+                changed = true;
+            }
+
+            // The dartboard behavior needs a Transform child named "Target"
+            // it raycasts against. The behavior tolerates a missing target
+            // (every throw becomes a miss) but a playtester can't tell
+            // "the dartboard is real but I'm aiming wrong" from "the
+            // dartboard is just unplayable", so we guarantee a target
+            // child exists for any dartboard station even if the behavior
+            // was already wired.
+            if (station.GetComponent<DartboardStationBehavior>() != null)
+            {
+                if (EnsureDartboardTarget(station))
+                    changed = true;
+            }
+
+            return changed;
+        }
+
+        private static void AddBehaviorForRole(ShipStation station)
+        {
+            switch (station.Role)
+            {
+                case ShipStationRole.Pilot:
+                    station.gameObject.AddComponent<PilotStationBehavior>();
+                    return;
+                case ShipStationRole.HolographicBoard:
+                    station.gameObject.AddComponent<MissionVoteBehavior>();
+                    return;
+                case ShipStationRole.MiniGame:
+                    station.gameObject.AddComponent<DartboardStationBehavior>();
+                    return;
+                case ShipStationRole.Customization:
+                    // BoomboxStationBehavior [RequireComponent(AudioSource)] —
+                    // Unity auto-adds the AudioSource on AddComponent.
+                    station.gameObject.AddComponent<BoomboxStationBehavior>();
+                    return;
+                case ShipStationRole.Utility:
+                default:
+                    station.gameObject.AddComponent<LegacyOccupancyBehavior>();
+                    return;
+            }
+        }
+
+        // Creates a "Target" child GameObject on the dartboard station if
+        // missing. The child's forward axis is the dartboard's face normal
+        // (per DartboardStationBehavior.ResolveThrow), so positioning it
+        // at local (0, 1.2, 0.1) with identity rotation puts the target
+        // plane at chest height, facing the same way as the station — a
+        // player standing in front of the station looks straight at it.
+        private static bool EnsureDartboardTarget(ShipStation station)
+        {
+            var existing = station.transform.Find("Target");
+            if (existing != null) return false;
+
+            var target = new GameObject("Target");
+            target.transform.SetParent(station.transform, worldPositionStays: false);
+            target.transform.localPosition = new Vector3(0f, 1.2f, 0.1f);
+            target.transform.localRotation = Quaternion.identity;
+            EditorUtility.SetDirty(target);
+            return true;
         }
     }
 }

--- a/Space Game/Assets/Scripts/Editor/FriendSlopSceneWiringRepair.ShipStationBehaviors.cs
+++ b/Space Game/Assets/Scripts/Editor/FriendSlopSceneWiringRepair.ShipStationBehaviors.cs
@@ -1,0 +1,62 @@
+#if UNITY_EDITOR
+using FriendSlop.Ship;
+using UnityEditor;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+
+namespace FriendSlop.Editor
+{
+    // PR §6 "Scene wiring". Per D-001 nobody hand-edits scene YAML; the
+    // canonical way to wire a new component onto a scene GameObject is a
+    // repair-tool pass.
+    //
+    // This pass guarantees every existing ShipStation in ShipInterior has a
+    // matching ShipStationBehavior sibling component:
+    //
+    //   role == Pilot         ->  PilotStationBehavior
+    //   anything else         ->  LegacyOccupancyBehavior
+    //
+    // It does NOT instantiate new GameObjects for MissionVote / Boombox /
+    // Dartboard stations — those want fresh GameObjects with collider +
+    // visual children that the repair tool can't synthesise from code
+    // alone. Authoring those stations is a follow-up PR.
+    //
+    // Repair is idempotent: if the sibling already exists we leave it
+    // alone, preserving any inspector tuning a designer did. The scene is
+    // only marked dirty when something actually changed.
+    public static partial class FriendSlopSceneWiringRepair
+    {
+        private static bool EnsureStationBehaviorSiblings(Scene scene)
+        {
+            if (!scene.IsValid()) return false;
+
+            var stations = Object.FindObjectsByType<ShipStation>(
+                FindObjectsInactive.Include, FindObjectsSortMode.None);
+            var changed = false;
+
+            for (var i = 0; i < stations.Length; i++)
+            {
+                var station = stations[i];
+                if (station == null || station.gameObject.scene != scene) continue;
+
+                var existing = station.GetComponent<ShipStationBehavior>();
+                if (existing != null) continue;
+
+                if (station.Role == ShipStationRole.Pilot)
+                {
+                    station.gameObject.AddComponent<PilotStationBehavior>();
+                }
+                else
+                {
+                    station.gameObject.AddComponent<LegacyOccupancyBehavior>();
+                }
+
+                EditorUtility.SetDirty(station.gameObject);
+                changed = true;
+            }
+
+            return changed;
+        }
+    }
+}
+#endif

--- a/Space Game/Assets/Scripts/Editor/FriendSlopSceneWiringRepair.ShipStationBehaviors.cs.meta
+++ b/Space Game/Assets/Scripts/Editor/FriendSlopSceneWiringRepair.ShipStationBehaviors.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8be93d6ade474fcda767f7bf4ced41f0
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Space Game/Assets/Scripts/Editor/FriendSlopSceneWiringRepair.cs
+++ b/Space Game/Assets/Scripts/Editor/FriendSlopSceneWiringRepair.cs
@@ -14,7 +14,7 @@ using UnityEngine.SceneManagement;
 
 namespace FriendSlop.Editor
 {
-    public static class FriendSlopSceneWiringRepair
+    public static partial class FriendSlopSceneWiringRepair
     {
         private const string PrototypeScenePath = "Assets/Scenes/FriendSlopPrototype.unity";
         private const string ShipInteriorScenePath = "Assets/Scenes/ShipInterior.unity";
@@ -161,6 +161,11 @@ namespace FriendSlop.Editor
                     changed = true;
                 }
             }
+
+            // Add behavior siblings to every ShipStation in the scene.
+            // Implemented in FriendSlopSceneWiringRepair.ShipStationBehaviors.cs
+            // (this file is over the 400-line cap; new code goes into a partial).
+            changed |= EnsureStationBehaviorSiblings(scene);
 
             if (changed)
                 EditorSceneManager.SaveScene(scene);

--- a/Space Game/Assets/Scripts/Ship/Behaviors.meta
+++ b/Space Game/Assets/Scripts/Ship/Behaviors.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 1cb3b212306243f4ae3cf9b175c1955a
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Space Game/Assets/Scripts/Ship/Behaviors/BoomboxStationBehavior.cs
+++ b/Space Game/Assets/Scripts/Ship/Behaviors/BoomboxStationBehavior.cs
@@ -1,0 +1,180 @@
+using FriendSlop.Player;
+using Unity.Netcode;
+using UnityEngine;
+
+namespace FriendSlop.Ship
+{
+    // Static-station boombox (v1: no carrying yet). Server-authoritative
+    // state machine: stopped -> playing track 0 -> playing track 1 -> ... ->
+    // stopped. Each press cycles to the next state.
+    //
+    // Playback sync: when the server starts a track it records
+    // NetworkManager.ServerTime as `_serverStartTime`; clients use
+    // BoomboxPlayback.ComputeLocalPlaybackTime to drop their local
+    // AudioSource head at the same offset so a late-joiner hears the same
+    // moment in the track. The pattern mirrors the public boombox in lots
+    // of Lethal-Company-style games.
+    //
+    // The boombox does NOT route through AudioCue — that layer is for short
+    // gameplay cues (loot pickup, meteor warning) with a procedural
+    // fallback. Looping music wants a real AudioClip on the GameObject and
+    // a registry-of-music slot is overkill for v1. When `tracks` is empty
+    // the boombox shows a placeholder prompt and stays silent — no
+    // procedural fallback.
+    [RequireComponent(typeof(AudioSource))]
+    public class BoomboxStationBehavior : ShipStationBehavior
+    {
+        [SerializeField] private AudioClip[] tracks;
+        [SerializeField] private float volume = 0.7f;
+
+        // -1 = stopped.
+        public NetworkVariable<int> TrackIndex = new(BoomboxPlayback.NoTrack);
+        public NetworkVariable<bool> IsPlaying = new(false);
+        public NetworkVariable<double> ServerStartTime = new(0d);
+
+        private AudioSource _audioSource;
+
+        private void Awake()
+        {
+            _audioSource = GetComponent<AudioSource>();
+            if (_audioSource != null)
+            {
+                _audioSource.loop = true;
+                _audioSource.playOnAwake = false;
+                _audioSource.spatialBlend = 1f; // 3D
+            }
+        }
+
+        public override void OnHostNetworkSpawn(ShipStation host)
+        {
+            TrackIndex.OnValueChanged += OnTrackChanged;
+            IsPlaying.OnValueChanged += OnIsPlayingChanged;
+            ApplyLocalPlayback();
+        }
+
+        public override void OnHostNetworkDespawn(ShipStation host)
+        {
+            TrackIndex.OnValueChanged -= OnTrackChanged;
+            IsPlaying.OnValueChanged -= OnIsPlayingChanged;
+
+            if (_audioSource != null && _audioSource.isPlaying)
+                _audioSource.Stop();
+        }
+
+        public override bool AllowsInteract(NetworkFirstPersonController player, ShipStation host)
+        {
+            // Boombox can be used by anyone — no occupancy gate.
+            return player != null && !player.IsDead && !player.IsBeingCarried.Value;
+        }
+
+        public override string BuildPrompt(NetworkFirstPersonController player, ShipStation host)
+        {
+            if (host == null) return string.Empty;
+
+            if (tracks == null || tracks.Length == 0)
+            {
+                return $"{host.DisplayName} (track slot empty)";
+            }
+
+            if (!IsPlaying.Value)
+            {
+                return $"E play {host.DisplayName}";
+            }
+
+            var idx = TrackIndex.Value;
+            if (idx < 0 || idx >= tracks.Length)
+            {
+                return $"E next track on {host.DisplayName}";
+            }
+
+            var clip = tracks[idx];
+            var label = clip != null ? clip.name : $"track {idx + 1}";
+            return $"E next ({label}) on {host.DisplayName}";
+        }
+
+        public override void HandleInteractServer(ulong senderClientId, ShipStation host)
+        {
+            if (!IsServer) return;
+
+            var trackCount = tracks != null ? tracks.Length : 0;
+            if (trackCount == 0)
+            {
+                // No tracks authored — interact is a no-op.
+                return;
+            }
+
+            if (!IsPlaying.Value)
+            {
+                TrackIndex.Value = 0;
+                IsPlaying.Value = true;
+                ServerStartTime.Value = NetworkManager.ServerTime.Time;
+                return;
+            }
+
+            var next = BoomboxPlayback.NextTrack(TrackIndex.Value, trackCount);
+            if (next == BoomboxPlayback.NoTrack)
+            {
+                IsPlaying.Value = false;
+                TrackIndex.Value = BoomboxPlayback.NoTrack;
+                return;
+            }
+
+            // Stop after cycling past the last track: if we just wrapped to
+            // 0 (meaning current was the final track), stop instead of
+            // looping the playlist.
+            if (next == 0 && TrackIndex.Value == trackCount - 1)
+            {
+                IsPlaying.Value = false;
+                TrackIndex.Value = BoomboxPlayback.NoTrack;
+                return;
+            }
+
+            TrackIndex.Value = next;
+            ServerStartTime.Value = NetworkManager.ServerTime.Time;
+        }
+
+        private void OnTrackChanged(int previous, int current)
+        {
+            ApplyLocalPlayback();
+        }
+
+        private void OnIsPlayingChanged(bool previous, bool current)
+        {
+            ApplyLocalPlayback();
+        }
+
+        private void ApplyLocalPlayback()
+        {
+            if (_audioSource == null) return;
+
+            var trackCount = tracks != null ? tracks.Length : 0;
+            var idx = TrackIndex.Value;
+
+            if (!IsPlaying.Value || trackCount == 0 || idx < 0 || idx >= trackCount)
+            {
+                if (_audioSource.isPlaying) _audioSource.Stop();
+                return;
+            }
+
+            var clip = tracks[idx];
+            if (clip == null)
+            {
+                if (_audioSource.isPlaying) _audioSource.Stop();
+                return;
+            }
+
+            _audioSource.clip = clip;
+            _audioSource.volume = Mathf.Clamp01(volume);
+
+            var now = NetworkManager != null
+                ? NetworkManager.ServerTime.Time
+                : ServerStartTime.Value;
+            var offset = BoomboxPlayback.ComputeLocalPlaybackTime(
+                ServerStartTime.Value, now, clip.length);
+            _audioSource.time = (float)offset;
+
+            if (!_audioSource.isPlaying)
+                _audioSource.Play();
+        }
+    }
+}

--- a/Space Game/Assets/Scripts/Ship/Behaviors/BoomboxStationBehavior.cs.meta
+++ b/Space Game/Assets/Scripts/Ship/Behaviors/BoomboxStationBehavior.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5e122585bbcf4adfb8472eecacc3169a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Space Game/Assets/Scripts/Ship/Behaviors/DartboardStationBehavior.cs
+++ b/Space Game/Assets/Scripts/Ship/Behaviors/DartboardStationBehavior.cs
@@ -1,0 +1,336 @@
+using System;
+using FriendSlop.Player;
+using Unity.Netcode;
+using UnityEngine;
+
+namespace FriendSlop.Ship
+{
+    // Per-player aggregate score on this dartboard. The clientId+totalScore
+    // pair plus best-throw are enough for the scoreboard UI.
+    public struct DartScoreEntry : INetworkSerializable, IEquatable<DartScoreEntry>
+    {
+        public ulong clientId;
+        public int totalScore;
+        public int bestThrow;
+
+        public void NetworkSerialize<T>(BufferSerializer<T> serializer) where T : IReaderWriter
+        {
+            serializer.SerializeValue(ref clientId);
+            serializer.SerializeValue(ref totalScore);
+            serializer.SerializeValue(ref bestThrow);
+        }
+
+        public bool Equals(DartScoreEntry other)
+        {
+            return clientId == other.clientId
+                && totalScore == other.totalScore
+                && bestThrow == other.bestThrow;
+        }
+
+        public override bool Equals(object obj)
+        {
+            return obj is DartScoreEntry other && Equals(other);
+        }
+
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(clientId, totalScore, bestThrow);
+        }
+    }
+
+    // Hitscan-style dart toss. No projectile prefab — the owner sends the
+    // camera ray + charge to the server, the server raycasts against the
+    // dartboard's target plane (clamping range and validating origin
+    // against the player to prevent trust-the-client hits), scores via
+    // DartScoring.ScoreForRadius, and broadcasts a hit ClientRpc so every
+    // client can show a local floating "Direct hit! +25" overlay.
+    //
+    // Charge is bookkept locally on the owner (per CLAUDE.md "trust the
+    // server" rule — charge01 is clamped and only used to scale a fudge
+    // factor for the hit position, not the score itself).
+    //
+    // No NetworkObjects are spawned per throw. Floating-text UI is a UI-
+    // layer responsibility and gets the event via an `event System.Action`
+    // on this component.
+    public class DartboardStationBehavior : ShipStationBehavior
+    {
+        // The mesh / collider that represents the target face. If null the
+        // behavior tries to find a child named "Target".
+        [SerializeField] private Transform target;
+
+        // Radius (world units) of the dartboard at radius01 = 1. Used to
+        // convert hit distance into normalized radius for ScoreForRadius.
+        [SerializeField] private float targetRadius = 0.5f;
+
+        // Maximum throw distance the server will accept. Throws beyond this
+        // are rejected (trust-the-server invariant on client-supplied
+        // vectors per CLAUDE.md §3).
+        [SerializeField] private float maxThrowDistance = 25f;
+
+        public NetworkList<DartScoreEntry> Scoreboard;
+
+        // Client-side floating-text hook. UI layer subscribes; the event
+        // fires once per throw on every client when the server broadcasts.
+        public event System.Action<DartHitInfo> LocalThrowResolved;
+
+        public struct DartHitInfo
+        {
+            public ulong clientId;
+            public Vector3 hitPosition;
+            public int score;
+            public bool isMiss;
+        }
+
+        // ── Lifecycle ──────────────────────────────────────────────────
+
+        private void Awake()
+        {
+            Scoreboard = new NetworkList<DartScoreEntry>();
+            if (target == null)
+                target = transform.Find("Target");
+        }
+
+        public override bool AllowsInteract(NetworkFirstPersonController player, ShipStation host)
+        {
+            // Like the boombox: anyone alive can throw.
+            return player != null && !player.IsDead && !player.IsBeingCarried.Value;
+        }
+
+        public override string BuildPrompt(NetworkFirstPersonController player, ShipStation host)
+        {
+            if (host == null) return string.Empty;
+
+            var top = FormatTop3();
+            if (string.IsNullOrEmpty(top))
+                return $"E throw dart at {host.DisplayName}";
+
+            return $"E throw dart at {host.DisplayName} | {top}";
+        }
+
+        // The interact RPC path on ShipStation is the "I want to throw"
+        // press; for the dartboard the actual throw goes through a separate
+        // RPC below so it can carry the camera vector + charge. We treat
+        // the standard interact as a "ready to throw" toast.
+        public override void HandleInteractServer(ulong senderClientId, ShipStation host)
+        {
+            // Default press = nothing happens on the server. The owner-side
+            // input handler reads "interact pressed" as "start charge" and
+            // "interact released" as "fire RequestThrowServerRpc". Charge
+            // bookkeeping is fully owner-local — see the UI layer when
+            // dart-charge input gets wired.
+        }
+
+        // ── Throw RPC ──────────────────────────────────────────────────
+
+        [Rpc(SendTo.Server, InvokePermission = RpcInvokePermission.Everyone)]
+        public void RequestThrowServerRpc(
+            Vector3 cameraOrigin,
+            Vector3 cameraForward,
+            float charge01,
+            RpcParams rpcParams = default)
+        {
+            if (!IsServer) return;
+
+            // Validate client-supplied vectors (CLAUDE.md §3).
+            if (!IsFiniteVector(cameraOrigin) || !IsFiniteVector(cameraForward))
+                return;
+
+            var sender = rpcParams.Receive.SenderClientId;
+
+            if (cameraForward.sqrMagnitude < 0.0001f)
+                return;
+            cameraForward = cameraForward.normalized;
+
+            charge01 = Mathf.Clamp01(charge01);
+
+            var hitInfo = ResolveThrow(cameraOrigin, cameraForward);
+            if (!hitInfo.HasValue)
+            {
+                BroadcastMissClientRpc(sender);
+                return;
+            }
+
+            var hit = hitInfo.Value;
+            var score = DartScoring.ScoreForRadius(hit.radius01);
+
+            AddScoreForClient(sender, score);
+
+            BroadcastHitClientRpc(sender, hit.worldPosition, score);
+        }
+
+        private struct HitData
+        {
+            public Vector3 worldPosition;
+            public float radius01;
+        }
+
+        // Raycast against the target's plane. Returns null when the ray
+        // misses the plane, hits behind the player, or exceeds
+        // maxThrowDistance.
+        private HitData? ResolveThrow(Vector3 cameraOrigin, Vector3 cameraForward)
+        {
+            if (target == null) return null;
+            if (targetRadius <= 0f) return null;
+
+            // Plane defined by target.position + target.forward as normal.
+            var planeOrigin = target.position;
+            var planeNormal = target.forward;
+            if (planeNormal.sqrMagnitude < 0.0001f) return null;
+            planeNormal.Normalize();
+
+            var denominator = Vector3.Dot(planeNormal, cameraForward);
+            if (Mathf.Abs(denominator) < 0.0001f) return null;
+
+            var t = Vector3.Dot(planeOrigin - cameraOrigin, planeNormal) / denominator;
+            if (t < 0f) return null;
+            if (t > maxThrowDistance) return null;
+
+            var worldHit = cameraOrigin + cameraForward * t;
+            var planar = worldHit - planeOrigin;
+
+            // Distance from the target center along the dartboard's face.
+            // We project away the normal component (should already be ~0)
+            // and divide by targetRadius for the normalized hit radius.
+            var alongNormal = Vector3.Dot(planar, planeNormal);
+            var inPlane = planar - planeNormal * alongNormal;
+            var radius = inPlane.magnitude;
+            var radius01 = radius / targetRadius;
+
+            return new HitData
+            {
+                worldPosition = worldHit,
+                radius01 = radius01,
+            };
+        }
+
+        // ── Scoreboard mutation ────────────────────────────────────────
+
+        private void AddScoreForClient(ulong clientId, int score)
+        {
+            if (Scoreboard == null) return;
+
+            for (var i = 0; i < Scoreboard.Count; i++)
+            {
+                if (Scoreboard[i].clientId != clientId) continue;
+
+                var existing = Scoreboard[i];
+                Scoreboard[i] = new DartScoreEntry
+                {
+                    clientId = clientId,
+                    totalScore = existing.totalScore + score,
+                    bestThrow = Mathf.Max(existing.bestThrow, score),
+                };
+                return;
+            }
+
+            Scoreboard.Add(new DartScoreEntry
+            {
+                clientId = clientId,
+                totalScore = score,
+                bestThrow = score,
+            });
+        }
+
+        // ── Floating-text fan-out ──────────────────────────────────────
+
+        [ClientRpc]
+        private void BroadcastHitClientRpc(ulong clientId, Vector3 position, int score)
+        {
+            LocalThrowResolved?.Invoke(new DartHitInfo
+            {
+                clientId = clientId,
+                hitPosition = position,
+                score = score,
+                isMiss = score <= 0,
+            });
+        }
+
+        [ClientRpc]
+        private void BroadcastMissClientRpc(ulong clientId)
+        {
+            LocalThrowResolved?.Invoke(new DartHitInfo
+            {
+                clientId = clientId,
+                hitPosition = Vector3.zero,
+                score = 0,
+                isMiss = true,
+            });
+        }
+
+        // ── Prompt formatting ──────────────────────────────────────────
+
+        private string FormatTop3()
+        {
+            if (Scoreboard == null || Scoreboard.Count == 0) return string.Empty;
+
+            // Find top three totalScore values; ties broken by clientId asc
+            // for determinism.
+            Span<DartScoreEntry> top = stackalloc DartScoreEntry[3];
+            var topCount = 0;
+            for (var i = 0; i < Scoreboard.Count; i++)
+            {
+                var entry = Scoreboard[i];
+                InsertIntoTop(top, ref topCount, entry);
+            }
+
+            var sb = new System.Text.StringBuilder();
+            for (var i = 0; i < topCount; i++)
+            {
+                if (i > 0) sb.Append(' ');
+                sb.Append('#').Append(i + 1).Append(':').Append(top[i].totalScore);
+            }
+            return sb.ToString();
+        }
+
+        private static void InsertIntoTop(Span<DartScoreEntry> top, ref int count, DartScoreEntry candidate)
+        {
+            // Compare against the slot with the lowest score, replace if
+            // candidate beats it (ties broken by lower clientId winning).
+            if (count < top.Length)
+            {
+                top[count] = candidate;
+                count++;
+                SortTop(top, count);
+                return;
+            }
+
+            var worstIdx = count - 1;
+            var worst = top[worstIdx];
+            if (candidate.totalScore > worst.totalScore
+                || (candidate.totalScore == worst.totalScore && candidate.clientId < worst.clientId))
+            {
+                top[worstIdx] = candidate;
+                SortTop(top, count);
+            }
+        }
+
+        private static void SortTop(Span<DartScoreEntry> top, int count)
+        {
+            // Simple insertion sort, n=3 max — descending totalScore, then
+            // ascending clientId.
+            for (var i = 1; i < count; i++)
+            {
+                var key = top[i];
+                var j = i - 1;
+                while (j >= 0 && IsBetter(key, top[j]))
+                {
+                    top[j + 1] = top[j];
+                    j--;
+                }
+                top[j + 1] = key;
+            }
+        }
+
+        private static bool IsBetter(DartScoreEntry a, DartScoreEntry b)
+        {
+            if (a.totalScore != b.totalScore) return a.totalScore > b.totalScore;
+            return a.clientId < b.clientId;
+        }
+
+        private static bool IsFiniteVector(Vector3 v)
+        {
+            return !(float.IsNaN(v.x) || float.IsNaN(v.y) || float.IsNaN(v.z)
+                  || float.IsInfinity(v.x) || float.IsInfinity(v.y) || float.IsInfinity(v.z));
+        }
+    }
+}

--- a/Space Game/Assets/Scripts/Ship/Behaviors/DartboardStationBehavior.cs.meta
+++ b/Space Game/Assets/Scripts/Ship/Behaviors/DartboardStationBehavior.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6a0f0945012f43fda50d4c0db6e25488
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Space Game/Assets/Scripts/Ship/Behaviors/LegacyOccupancyBehavior.cs
+++ b/Space Game/Assets/Scripts/Ship/Behaviors/LegacyOccupancyBehavior.cs
@@ -1,0 +1,47 @@
+using FriendSlop.Player;
+
+namespace FriendSlop.Ship
+{
+    // Bare-minimum behavior: claim the station, release it on second press.
+    // Mirrors the non-Pilot enum branches of the original ShipStation.
+    // Use this on any station prefab that doesn't have a specialised
+    // behavior — it's the "no-op skin" so every station ends up with a
+    // sibling component, which lets the rest of the codebase rely on the
+    // ShipStationBehavior path without falling back to the legacy enum
+    // branch.
+    public class LegacyOccupancyBehavior : ShipStationBehavior
+    {
+        public override string BuildPrompt(NetworkFirstPersonController player, ShipStation host)
+        {
+            if (host == null) return string.Empty;
+
+            if (player != null && host.OccupantClientId.Value == player.OwnerClientId)
+            {
+                return $"E leave {host.DisplayName}";
+            }
+
+            if (host.IsOccupied)
+            {
+                return $"{host.DisplayName} in use";
+            }
+
+            return $"E use {host.DisplayName}";
+        }
+
+        public override void HandleInteractServer(ulong senderClientId, ShipStation host)
+        {
+            if (host == null) return;
+
+            if (host.OccupantClientId.Value == senderClientId)
+            {
+                host.OccupantClientId.Value = ShipStation.NoOccupant;
+                return;
+            }
+
+            if (host.OccupantClientId.Value == ShipStation.NoOccupant)
+            {
+                host.OccupantClientId.Value = senderClientId;
+            }
+        }
+    }
+}

--- a/Space Game/Assets/Scripts/Ship/Behaviors/LegacyOccupancyBehavior.cs.meta
+++ b/Space Game/Assets/Scripts/Ship/Behaviors/LegacyOccupancyBehavior.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e3c0f1dca22d4100b378108c33fff27a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Space Game/Assets/Scripts/Ship/Behaviors/MissionVoteBehavior.cs
+++ b/Space Game/Assets/Scripts/Ship/Behaviors/MissionVoteBehavior.cs
@@ -1,0 +1,144 @@
+using System;
+using FriendSlop.Player;
+using Unity.Netcode;
+
+namespace FriendSlop.Ship
+{
+    // Per-client vote record. NetworkList<T> requires INetworkSerializable +
+    // IEquatable<T>; the latter must match by content (clientId+candidate)
+    // so removals via NetworkList<T>.Remove find the right entry.
+    public struct MissionVoteEntry : INetworkSerializable, IEquatable<MissionVoteEntry>
+    {
+        public ulong clientId;
+        public byte candidateIndex;
+
+        public void NetworkSerialize<T>(BufferSerializer<T> serializer) where T : IReaderWriter
+        {
+            serializer.SerializeValue(ref clientId);
+            serializer.SerializeValue(ref candidateIndex);
+        }
+
+        public bool Equals(MissionVoteEntry other)
+        {
+            return clientId == other.clientId && candidateIndex == other.candidateIndex;
+        }
+
+        public override bool Equals(object obj)
+        {
+            return obj is MissionVoteEntry other && Equals(other);
+        }
+
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(clientId, candidateIndex);
+        }
+    }
+
+    // Mission-vote station: three candidate slots, one vote per client, the
+    // press cycles the caller's vote (no vote -> 0 -> 1 -> 2 -> no vote).
+    //
+    // This behavior intentionally doesn't pick the next planet — Pilot still
+    // owns ServerStartRound, which still asks RoundManager for the next
+    // planet the way it did before. A downstream PR wires
+    // MissionVoteTally.WinningCandidate into PlanetCatalog selection.
+    //
+    // Server authority: vote state is a NetworkList<MissionVoteEntry> owned
+    // by the server. Clients send a parameterless RPC; the server reads the
+    // RPC sender, cycles their vote, replicates.
+    public class MissionVoteBehavior : ShipStationBehavior
+    {
+        public const int CandidateCount = 3;
+
+        public NetworkList<MissionVoteEntry> Votes;
+
+        private void Awake()
+        {
+            Votes = new NetworkList<MissionVoteEntry>();
+        }
+
+        public override bool AllowsInteract(NetworkFirstPersonController player, ShipStation host)
+        {
+            // Anyone alive can vote — no occupancy gate.
+            return player != null && !player.IsDead && !player.IsBeingCarried.Value;
+        }
+
+        public override string BuildPrompt(NetworkFirstPersonController player, ShipStation host)
+        {
+            if (host == null) return string.Empty;
+
+            var tallies = TallyVotes();
+            var label = $"[{tallies[0]}:{tallies[1]}:{tallies[2]}] E vote {host.DisplayName}";
+
+            if (player == null) return label;
+
+            var currentVote = FindCurrentVote(player.OwnerClientId);
+            if (currentVote == MissionVoteTally.NoVote)
+                return $"{label} (you: no vote)";
+
+            return $"{label} (you: candidate {currentVote + 1})";
+        }
+
+        public override void HandleInteractServer(ulong senderClientId, ShipStation host)
+        {
+            if (!IsServer || Votes == null) return;
+
+            var current = FindCurrentVote(senderClientId);
+            var next = MissionVoteTally.CycleVote(current, CandidateCount);
+
+            // Remove the existing entry (if any) so we don't accumulate
+            // ghost votes when a client cycles past "no vote".
+            RemoveVoteFor(senderClientId);
+
+            if (next != MissionVoteTally.NoVote)
+            {
+                Votes.Add(new MissionVoteEntry
+                {
+                    clientId = senderClientId,
+                    candidateIndex = next,
+                });
+            }
+        }
+
+        // Server-side: removes the existing entry for this client without
+        // depending on Equals (which has to match candidate index too).
+        private void RemoveVoteFor(ulong clientId)
+        {
+            for (var i = Votes.Count - 1; i >= 0; i--)
+            {
+                if (Votes[i].clientId == clientId)
+                    Votes.RemoveAt(i);
+            }
+        }
+
+        // Looks up the caller's current vote; NoVote if they haven't voted.
+        public byte FindCurrentVote(ulong clientId)
+        {
+            if (Votes == null) return MissionVoteTally.NoVote;
+            for (var i = 0; i < Votes.Count; i++)
+            {
+                if (Votes[i].clientId == clientId)
+                    return Votes[i].candidateIndex;
+            }
+            return MissionVoteTally.NoVote;
+        }
+
+        // Returns the per-candidate vote count snapshot. Index = candidate.
+        public int[] TallyVotes()
+        {
+            var tallies = new int[CandidateCount];
+            if (Votes == null) return tallies;
+
+            for (var i = 0; i < Votes.Count; i++)
+            {
+                var idx = Votes[i].candidateIndex;
+                if (idx < CandidateCount) tallies[idx]++;
+            }
+            return tallies;
+        }
+
+        public int? WinningCandidate()
+        {
+            return MissionVoteTally.WinningCandidate(TallyVotes());
+        }
+    }
+}

--- a/Space Game/Assets/Scripts/Ship/Behaviors/MissionVoteBehavior.cs.meta
+++ b/Space Game/Assets/Scripts/Ship/Behaviors/MissionVoteBehavior.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e79b5bffaaca48ef9352187bdb4ecedc
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Space Game/Assets/Scripts/Ship/Behaviors/PilotStationBehavior.cs
+++ b/Space Game/Assets/Scripts/Ship/Behaviors/PilotStationBehavior.cs
@@ -1,0 +1,66 @@
+using FriendSlop.Player;
+using FriendSlop.Round;
+
+namespace FriendSlop.Ship
+{
+    // Pilot seat. Default claim/release loop, plus the "start round" hook
+    // that the legacy enum-branch logic in ShipStation used to own.
+    //
+    // Round-start authority lives on RoundManager (see ServerStartRound) —
+    // this behavior just dispatches the call from the server-side interact
+    // handler when the phase is Lobby. No singletons: we reach
+    // RoundManager via RoundManagerRegistry (D-014).
+    public class PilotStationBehavior : ShipStationBehavior
+    {
+        public override string BuildPrompt(NetworkFirstPersonController player, ShipStation host)
+        {
+            if (host == null) return string.Empty;
+
+            if (CanStartRound())
+            {
+                return $"E start round from {host.DisplayName}";
+            }
+
+            if (player != null && host.OccupantClientId.Value == player.OwnerClientId)
+            {
+                return $"E leave {host.DisplayName}";
+            }
+
+            if (host.IsOccupied)
+            {
+                return $"{host.DisplayName} in use";
+            }
+
+            return $"E claim {host.DisplayName}";
+        }
+
+        public override void HandleInteractServer(ulong senderClientId, ShipStation host)
+        {
+            if (host == null) return;
+
+            if (CanStartRound())
+            {
+                var roundManager = RoundManagerRegistry.Current;
+                if (roundManager != null && roundManager.IsServer)
+                    roundManager.ServerStartRound();
+                return;
+            }
+
+            if (host.OccupantClientId.Value == senderClientId)
+            {
+                host.OccupantClientId.Value = ShipStation.NoOccupant;
+                return;
+            }
+
+            if (host.OccupantClientId.Value == ShipStation.NoOccupant)
+            {
+                host.OccupantClientId.Value = senderClientId;
+            }
+        }
+
+        private static bool CanStartRound()
+        {
+            return RoundManagerRegistry.IsCurrentPhase(RoundPhase.Lobby);
+        }
+    }
+}

--- a/Space Game/Assets/Scripts/Ship/Behaviors/PilotStationBehavior.cs.meta
+++ b/Space Game/Assets/Scripts/Ship/Behaviors/PilotStationBehavior.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 61196aa74dd94d42a8107cb927406b90
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Space Game/Assets/Scripts/Ship/SaluteCoordinator.cs
+++ b/Space Game/Assets/Scripts/Ship/SaluteCoordinator.cs
@@ -1,0 +1,189 @@
+using System;
+using System.Collections.Generic;
+using FriendSlop.Effects;
+using Unity.Netcode;
+using UnityEngine;
+using UnityEngine.Events;
+
+namespace FriendSlop.Ship
+{
+    // Per-client salute timestamp record. Replicated so any client UI can
+    // mirror the "who has saluted recently" set without an extra RPC.
+    public struct SaluteEntry : INetworkSerializable, IEquatable<SaluteEntry>
+    {
+        public ulong clientId;
+        public float saluteTime;
+
+        public void NetworkSerialize<T>(BufferSerializer<T> serializer) where T : IReaderWriter
+        {
+            serializer.SerializeValue(ref clientId);
+            serializer.SerializeValue(ref saluteTime);
+        }
+
+        public bool Equals(SaluteEntry other)
+        {
+            return clientId == other.clientId
+                && Mathf.Approximately(saluteTime, other.saluteTime);
+        }
+
+        public override bool Equals(object obj)
+        {
+            return obj is SaluteEntry other && Equals(other);
+        }
+
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(clientId, saluteTime);
+        }
+    }
+
+    // Coordinates the "Perfect Crew" salute: whenever every player who is
+    // currently occupying a ship station has saluted within a short rolling
+    // window (1.5s default), the coordinator fires a one-shot AudioCue +
+    // UnityEvent and clears the log to debounce.
+    //
+    // No singletons (D-014): owners reach the coordinator via
+    // SaluteCoordinatorRegistry.Current, which is populated by this
+    // component's own OnNetworkSpawn / OnNetworkDespawn.
+    //
+    // Server authority: RequestSaluteServerRpc is the only mutator. The
+    // window check runs inline at the end of each RPC — that's the only
+    // moment new state can satisfy the predicate, so there's no need for a
+    // per-frame poll (would also violate the "no FindObjectsByType in
+    // Update" rule).
+    [RequireComponent(typeof(NetworkObject))]
+    public class SaluteCoordinator : NetworkBehaviour
+    {
+        [SerializeField] private float windowSeconds = 1.5f;
+
+        public NetworkList<SaluteEntry> RecentSalutes;
+
+        // UI hook: clients subscribe to flash a tint when the coordinator
+        // resolves a Perfect Crew event.
+        public UnityEvent OnPerfectCrew;
+
+        private readonly List<ulong> _occupantsBuffer = new();
+        private readonly List<SaluteRecord> _recordsBuffer = new();
+
+        private void Awake()
+        {
+            RecentSalutes = new NetworkList<SaluteEntry>();
+            OnPerfectCrew ??= new UnityEvent();
+        }
+
+        public override void OnNetworkSpawn()
+        {
+            SaluteCoordinatorRegistry.Register(this);
+        }
+
+        public override void OnNetworkDespawn()
+        {
+            SaluteCoordinatorRegistry.Unregister(this);
+        }
+
+        public override void OnDestroy()
+        {
+            SaluteCoordinatorRegistry.Unregister(this);
+            base.OnDestroy();
+        }
+
+        // Public entry point — call from station code when a player presses
+        // the salute key while occupying a station.
+        [Rpc(SendTo.Server, InvokePermission = RpcInvokePermission.Everyone)]
+        public void RequestSaluteServerRpc(ulong clientId, RpcParams rpcParams = default)
+        {
+            if (!IsServer || RecentSalutes == null) return;
+
+            if (clientId != rpcParams.Receive.SenderClientId) return;
+
+            // Replace any previous entry from this client; we only ever care
+            // about the latest salute timestamp per client.
+            for (var i = RecentSalutes.Count - 1; i >= 0; i--)
+            {
+                if (RecentSalutes[i].clientId == clientId)
+                    RecentSalutes.RemoveAt(i);
+            }
+
+            RecentSalutes.Add(new SaluteEntry
+            {
+                clientId = clientId,
+                saluteTime = Time.time,
+            });
+
+            TryFirePerfectCrew();
+        }
+
+        // Server-side window evaluation. Called right after the salute log
+        // changes — that's the only moment the predicate can transition to
+        // true, so polling in Update is unnecessary (and forbidden by the
+        // "no FindObjectsByType in per-frame methods" guardrail).
+        private void TryFirePerfectCrew()
+        {
+            CollectOccupants(_occupantsBuffer);
+            if (_occupantsBuffer.Count == 0) return;
+
+            CollectRecords(_recordsBuffer);
+            var now = Time.time;
+
+            if (!SaluteWindow.AllOccupiedSaluteWithinWindow(
+                    _occupantsBuffer, _recordsBuffer, now, windowSeconds))
+                return;
+
+            PerfectCrewClientRpc(ComputeCentre());
+
+            // Debounce — clear the log so we don't fire again on the next
+            // salute press.
+            RecentSalutes.Clear();
+        }
+
+        [ClientRpc]
+        private void PerfectCrewClientRpc(Vector3 centerPosition)
+        {
+            // Placeholder cue: AudioCueId.LaunchIgnition stands in until a
+            // dedicated PerfectCrew enum entry lands in a later PR (the
+            // parent branch owns the enum; this PR doesn't extend it).
+            AudioCue.Play(AudioCueId.LaunchIgnition, centerPosition);
+            OnPerfectCrew?.Invoke();
+        }
+
+        // Returns the set of client ids currently occupying a ShipStation.
+        // Called from the RPC handler (NOT Update) so the FindObjectsByType
+        // call is bounded by player input rate, not framerate. Uses the
+        // FindObjectsByType + IsSpawned filter pattern from CLAUDE §9 —
+        // NetworkPrefabsList parks inactive templates in the bootstrap
+        // scene that we must not count as "occupied".
+        private void CollectOccupants(List<ulong> buffer)
+        {
+            buffer.Clear();
+            var stations = FindObjectsByType<ShipStation>(
+                FindObjectsInactive.Include, FindObjectsSortMode.None);
+            for (var i = 0; i < stations.Length; i++)
+            {
+                var station = stations[i];
+                if (station == null) continue;
+                var netObj = station.GetComponent<NetworkObject>();
+                if (netObj == null || !netObj.IsSpawned) continue;
+                if (!station.IsOccupied) continue;
+                buffer.Add(station.OccupantClientId.Value);
+            }
+        }
+
+        private void CollectRecords(List<SaluteRecord> buffer)
+        {
+            buffer.Clear();
+            if (RecentSalutes == null) return;
+            for (var i = 0; i < RecentSalutes.Count; i++)
+            {
+                var e = RecentSalutes[i];
+                buffer.Add(new SaluteRecord(e.clientId, e.saluteTime));
+            }
+        }
+
+        private Vector3 ComputeCentre()
+        {
+            // Cheap stand-in: just use our own transform. The actual cue
+            // attenuation is "good enough" since ShipInterior is small.
+            return transform.position;
+        }
+    }
+}

--- a/Space Game/Assets/Scripts/Ship/SaluteCoordinator.cs.meta
+++ b/Space Game/Assets/Scripts/Ship/SaluteCoordinator.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3579b87c5c7546a89488ea23f14b5f3d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Space Game/Assets/Scripts/Ship/SaluteCoordinatorRegistry.cs
+++ b/Space Game/Assets/Scripts/Ship/SaluteCoordinatorRegistry.cs
@@ -1,0 +1,35 @@
+using System;
+
+namespace FriendSlop.Ship
+{
+    // Narrow registry for the in-scene SaluteCoordinator. Mirrors
+    // DayNightCycleRegistry / RoundManagerRegistry — see D-014 (no singletons:
+    // owners self-register on spawn, unregister on despawn; callers ask the
+    // registry for the current instance, can't reach for a static `.Instance`).
+    public static class SaluteCoordinatorRegistry
+    {
+        public static event Action<SaluteCoordinator, SaluteCoordinator> CurrentChanged;
+
+        public static SaluteCoordinator Current { get; private set; }
+
+        internal static void Register(SaluteCoordinator coordinator)
+        {
+            if (coordinator == null || Current == coordinator)
+                return;
+
+            var previous = Current;
+            Current = coordinator;
+            CurrentChanged?.Invoke(previous, Current);
+        }
+
+        internal static void Unregister(SaluteCoordinator coordinator)
+        {
+            if (coordinator == null || Current != coordinator)
+                return;
+
+            var previous = Current;
+            Current = null;
+            CurrentChanged?.Invoke(previous, null);
+        }
+    }
+}

--- a/Space Game/Assets/Scripts/Ship/SaluteCoordinatorRegistry.cs.meta
+++ b/Space Game/Assets/Scripts/Ship/SaluteCoordinatorRegistry.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4634bd626d9c4aa9bfebf97bbe949e54
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Space Game/Assets/Scripts/Ship/ShipStation.cs
+++ b/Space Game/Assets/Scripts/Ship/ShipStation.cs
@@ -26,9 +26,28 @@ namespace FriendSlop.Ship
 
         public NetworkVariable<ulong> OccupantClientId = new(NoOccupant);
 
+        // Sibling-component behavior. When present it owns all interact
+        // semantics; when null the legacy enum-branch fallback below runs so
+        // existing prefabs with no behavior sibling stay working. The cache
+        // is populated in OnNetworkSpawn — see ShipStationBehavior for the
+        // contract.
+        private ShipStationBehavior _behavior;
+
         public ShipStationRole Role => role;
         public string DisplayName => string.IsNullOrWhiteSpace(displayName) ? name : displayName;
         public bool IsOccupied => OccupantClientId.Value != NoOccupant;
+        public bool RequiresShipPhase => requiresShipPhase;
+
+        public override void OnNetworkSpawn()
+        {
+            _behavior = GetComponent<ShipStationBehavior>();
+            _behavior?.OnHostNetworkSpawn(this);
+        }
+
+        public override void OnNetworkDespawn()
+        {
+            _behavior?.OnHostNetworkDespawn(this);
+        }
 
         public bool CanInteract(NetworkFirstPersonController player)
         {
@@ -43,11 +62,21 @@ namespace FriendSlop.Ship
                 return false;
             }
 
+            if (_behavior != null)
+            {
+                return _behavior.AllowsInteract(player, this);
+            }
+
             return !IsOccupied || OccupantClientId.Value == player.OwnerClientId;
         }
 
         public string GetPrompt(NetworkFirstPersonController player)
         {
+            if (_behavior != null)
+            {
+                return _behavior.BuildPrompt(player, this) ?? string.Empty;
+            }
+
             if (CanStartRoundFromStation())
             {
                 return $"E start round from {DisplayName}";
@@ -89,6 +118,12 @@ namespace FriendSlop.Ship
             if (requiresShipPhase && !RoundStateUtility.IsShipPhase(
                     RoundManagerRegistry.CurrentPhaseOrDefault()))
             {
+                return;
+            }
+
+            if (_behavior != null)
+            {
+                _behavior.HandleInteractServer(requestedClientId, this);
                 return;
             }
 

--- a/Space Game/Assets/Scripts/Ship/ShipStationBehavior.cs
+++ b/Space Game/Assets/Scripts/Ship/ShipStationBehavior.cs
@@ -1,0 +1,62 @@
+using FriendSlop.Player;
+using Unity.Netcode;
+using UnityEngine;
+
+namespace FriendSlop.Ship
+{
+    // Abstract base for a sibling component pattern that replaces the
+    // ShipStationRole enum branch as the canonical way to specialise a
+    // station. The pattern (cf. D-014: no singletons): a ShipStation hosts
+    // a generic occupancy NetworkVariable and an interact RPC; a sibling
+    // ShipStationBehavior on the same GameObject decides what the prompt
+    // says, what `AllowsInteract` means, and what the server does when the
+    // interact RPC fires.
+    //
+    // Each concrete subclass is a sibling component on the station's
+    // GameObject — there is no global registry, no singleton instance, and
+    // no scriptable-object "behavior catalog". Authoring a new station type
+    // is: add a new subclass + drop it on a new ShipStation prefab.
+    //
+    // Lifecycle: ShipStation.OnNetworkSpawn caches its sibling behavior
+    // (GetComponent<ShipStationBehavior>()) and forwards the spawn/despawn
+    // callbacks through OnHostNetworkSpawn / OnHostNetworkDespawn. The host
+    // is passed in to every contract method so the subclass doesn't have to
+    // cache it itself.
+    [RequireComponent(typeof(NetworkObject))]
+    public abstract class ShipStationBehavior : NetworkBehaviour
+    {
+        // Returns the prompt the player sees when looking at the station.
+        // Must be non-null (return "" for no prompt). Called on every client
+        // every frame the station has focus — keep it cheap.
+        public abstract string BuildPrompt(
+            NetworkFirstPersonController player,
+            ShipStation host);
+
+        // Server-only interact handler. The host has already validated that
+        // (a) the sender matches the rpc params client id, and (b) the ship-
+        // phase guard passes if `host.requiresShipPhase` is set. Subclasses
+        // therefore don't need to repeat those checks.
+        public abstract void HandleInteractServer(
+            ulong senderClientId,
+            ShipStation host);
+
+        // Gates whether the prompt shows / interact can fire. The default
+        // gate matches the original ShipStation behavior: "not occupied, or
+        // I'm the occupant". Subclasses override when their interaction
+        // semantics differ — MissionVote, for instance, never blocks anyone
+        // from voting.
+        public virtual bool AllowsInteract(
+            NetworkFirstPersonController player,
+            ShipStation host)
+        {
+            if (player == null || host == null) return false;
+            return !host.IsOccupied
+                || host.OccupantClientId.Value == player.OwnerClientId;
+        }
+
+        // Spawn / despawn hooks. Subclasses override to subscribe to
+        // NetworkVariable changes, build initial state, or undo same.
+        public virtual void OnHostNetworkSpawn(ShipStation host) { }
+        public virtual void OnHostNetworkDespawn(ShipStation host) { }
+    }
+}

--- a/Space Game/Assets/Scripts/Ship/ShipStationBehavior.cs.meta
+++ b/Space Game/Assets/Scripts/Ship/ShipStationBehavior.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 84416c0643964b4692a15e04e3ecb11a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Space Game/Assets/Tests/EditMode/Editor/BoomboxPlaybackTests.cs
+++ b/Space Game/Assets/Tests/EditMode/Editor/BoomboxPlaybackTests.cs
@@ -1,0 +1,116 @@
+using FriendSlop.Ship;
+using NUnit.Framework;
+
+namespace FriendSlop.Tests.EditMode
+{
+    // Pins BoomboxPlayback — the pure helpers behind BoomboxStationBehavior.
+    //   - NextTrack: (current+1) mod trackCount, with trackCount<=0 returning
+    //     NoTrack (-1).
+    //   - ComputeLocalPlaybackTime: wraps elapsed via mod clipLength so late
+    //     joiners drop into the same place everyone else is. Zero
+    //     clipLength returns 0 (no audio to align).
+    public class BoomboxPlaybackTests
+    {
+        // ── NextTrack ──────────────────────────────────────────────────
+
+        [Test]
+        public void NextTrack_ZeroCount_ReturnsNoTrack()
+        {
+            Assert.AreEqual(BoomboxPlayback.NoTrack, BoomboxPlayback.NextTrack(0, 0));
+            Assert.AreEqual(BoomboxPlayback.NoTrack, BoomboxPlayback.NextTrack(BoomboxPlayback.NoTrack, 0));
+        }
+
+        [Test]
+        public void NextTrack_NegativeCount_ReturnsNoTrack()
+        {
+            Assert.AreEqual(BoomboxPlayback.NoTrack, BoomboxPlayback.NextTrack(0, -3));
+        }
+
+        [Test]
+        public void NextTrack_FromNoTrack_GoesToZero()
+        {
+            // Starting from "stopped", the next track is the first one.
+            Assert.AreEqual(0, BoomboxPlayback.NextTrack(BoomboxPlayback.NoTrack, 3));
+        }
+
+        [Test]
+        public void NextTrack_FromZero_GoesToOne()
+        {
+            Assert.AreEqual(1, BoomboxPlayback.NextTrack(0, 3));
+        }
+
+        [Test]
+        public void NextTrack_FromLast_WrapsToZero()
+        {
+            Assert.AreEqual(0, BoomboxPlayback.NextTrack(2, 3));
+        }
+
+        [Test]
+        public void NextTrack_SingleTrack_StaysAtZero()
+        {
+            // One track => next always 0.
+            Assert.AreEqual(0, BoomboxPlayback.NextTrack(0, 1));
+            Assert.AreEqual(0, BoomboxPlayback.NextTrack(BoomboxPlayback.NoTrack, 1));
+        }
+
+        // ── ComputeLocalPlaybackTime ───────────────────────────────────
+
+        [Test]
+        public void ComputeLocalPlaybackTime_ZeroClipLength_ReturnsZero()
+        {
+            Assert.AreEqual(0d, BoomboxPlayback.ComputeLocalPlaybackTime(0d, 5d, 0f));
+        }
+
+        [Test]
+        public void ComputeLocalPlaybackTime_NegativeClipLength_ReturnsZero()
+        {
+            // Defensive: AudioClip.length should never be negative, but the
+            // helper must not divide by zero or produce NaN.
+            Assert.AreEqual(0d, BoomboxPlayback.ComputeLocalPlaybackTime(0d, 5d, -3f));
+        }
+
+        [Test]
+        public void ComputeLocalPlaybackTime_BeforeStart_ClampsToZero()
+        {
+            // Current < start (e.g., late-joiner with desynced clock):
+            // negative elapsed clamps to 0.
+            Assert.AreEqual(0d, BoomboxPlayback.ComputeLocalPlaybackTime(10d, 5d, 4f));
+        }
+
+        [Test]
+        public void ComputeLocalPlaybackTime_WithinFirstLoop_ReturnsElapsed()
+        {
+            // 5 seconds into a 10s clip = playback position 5.
+            Assert.AreEqual(5d, BoomboxPlayback.ComputeLocalPlaybackTime(0d, 5d, 10f), 0.0001d);
+        }
+
+        [Test]
+        public void ComputeLocalPlaybackTime_ExactlyOneLoop_Returns0()
+        {
+            // Elapsed == clipLength means "starts of next loop" -> mod = 0.
+            Assert.AreEqual(0d, BoomboxPlayback.ComputeLocalPlaybackTime(0d, 10d, 10f), 0.0001d);
+        }
+
+        [Test]
+        public void ComputeLocalPlaybackTime_PartwayThroughSecondLoop_ReturnsModulo()
+        {
+            // 15s elapsed on a 10s clip -> position 5.
+            Assert.AreEqual(5d, BoomboxPlayback.ComputeLocalPlaybackTime(0d, 15d, 10f), 0.0001d);
+        }
+
+        [Test]
+        public void ComputeLocalPlaybackTime_MultipleLoops_ReturnsModulo()
+        {
+            // 17s elapsed on a 4s clip -> 17 mod 4 = 1.
+            Assert.AreEqual(1d, BoomboxPlayback.ComputeLocalPlaybackTime(0d, 17d, 4f), 0.0001d);
+        }
+
+        [Test]
+        public void ComputeLocalPlaybackTime_NonZeroStart_SubtractsBeforeMod()
+        {
+            // server started at t=100, currentServerTime=107, clipLength=3
+            // -> elapsed=7, 7 mod 3 = 1.
+            Assert.AreEqual(1d, BoomboxPlayback.ComputeLocalPlaybackTime(100d, 107d, 3f), 0.0001d);
+        }
+    }
+}

--- a/Space Game/Assets/Tests/EditMode/Editor/BoomboxPlaybackTests.cs.meta
+++ b/Space Game/Assets/Tests/EditMode/Editor/BoomboxPlaybackTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 14f1dfcc3daa4a2fa25d22fc7b7e4519
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Space Game/Assets/Tests/EditMode/Editor/DartScoringTests.cs
+++ b/Space Game/Assets/Tests/EditMode/Editor/DartScoringTests.cs
@@ -1,0 +1,132 @@
+using FriendSlop.Ship;
+using NUnit.Framework;
+
+namespace FriendSlop.Tests.EditMode
+{
+    // Pins DartScoring.ScoreForRadius — the radius bands are the contract
+    // and any rebalance has to move a test. Each band is checked at its
+    // lower edge, mid-band, and just inside the upper boundary. Miss at
+    // radius > 1.0.
+    public class DartScoringTests
+    {
+        [Test]
+        public void Bullseye_ExactZero_Returns50()
+        {
+            Assert.AreEqual(50, DartScoring.ScoreForRadius(0f));
+        }
+
+        [Test]
+        public void Bullseye_MidBand_Returns50()
+        {
+            Assert.AreEqual(50, DartScoring.ScoreForRadius(0.04f));
+        }
+
+        [Test]
+        public void Bullseye_UpperEdge_Returns50()
+        {
+            // 0.08 is inclusive.
+            Assert.AreEqual(50, DartScoring.ScoreForRadius(0.08f));
+        }
+
+        [Test]
+        public void InnerRing_JustAboveBullseye_Returns25()
+        {
+            Assert.AreEqual(25, DartScoring.ScoreForRadius(0.081f));
+        }
+
+        [Test]
+        public void InnerRing_MidBand_Returns25()
+        {
+            Assert.AreEqual(25, DartScoring.ScoreForRadius(0.15f));
+        }
+
+        [Test]
+        public void InnerRing_UpperEdge_Returns25()
+        {
+            Assert.AreEqual(25, DartScoring.ScoreForRadius(0.2f));
+        }
+
+        [Test]
+        public void MiddleRing_MidBand_Returns10()
+        {
+            Assert.AreEqual(10, DartScoring.ScoreForRadius(0.3f));
+        }
+
+        [Test]
+        public void MiddleRing_UpperEdge_Returns10()
+        {
+            Assert.AreEqual(10, DartScoring.ScoreForRadius(0.4f));
+        }
+
+        [Test]
+        public void OuterRing_MidBand_Returns5()
+        {
+            Assert.AreEqual(5, DartScoring.ScoreForRadius(0.5f));
+        }
+
+        [Test]
+        public void OuterRing_UpperEdge_Returns5()
+        {
+            Assert.AreEqual(5, DartScoring.ScoreForRadius(0.65f));
+        }
+
+        [Test]
+        public void Edge_MidBand_Returns1()
+        {
+            Assert.AreEqual(1, DartScoring.ScoreForRadius(0.8f));
+        }
+
+        [Test]
+        public void Edge_BoundaryRadiusOne_Returns1()
+        {
+            // Exactly 1.0 still scores 1 — only strictly > 1 misses.
+            Assert.AreEqual(1, DartScoring.ScoreForRadius(1.0f));
+        }
+
+        [Test]
+        public void Miss_JustOverOne_ReturnsZero()
+        {
+            Assert.AreEqual(0, DartScoring.ScoreForRadius(1.0001f));
+        }
+
+        [Test]
+        public void Miss_Far_ReturnsZero()
+        {
+            Assert.AreEqual(0, DartScoring.ScoreForRadius(5f));
+        }
+
+        [Test]
+        public void NegativeRadius_ClampsToBullseye()
+        {
+            // A negative radius is nonsense but shouldn't crash; clamping to
+            // bullseye is the friendliest behavior.
+            Assert.AreEqual(50, DartScoring.ScoreForRadius(-0.5f));
+        }
+
+        [Test]
+        public void FindBest_NullList_ReturnsZero()
+        {
+            Assert.AreEqual(0, DartScoring.FindBest(null));
+        }
+
+        [Test]
+        public void FindBest_EmptyList_ReturnsZero()
+        {
+            Assert.AreEqual(0, DartScoring.FindBest(new int[0]));
+        }
+
+        [Test]
+        public void FindBest_PicksHighest()
+        {
+            Assert.AreEqual(50, DartScoring.FindBest(new[] { 5, 10, 25, 50, 25 }));
+        }
+
+        [Test]
+        public void FindBest_AllNegative_ReturnsZero()
+        {
+            // FindBest starts at 0 and only replaces with strictly greater
+            // entries — negative scores stay below the floor.
+            Assert.AreEqual(0, DartScoring.FindBest(new[] { -5, -10 }));
+        }
+    }
+}

--- a/Space Game/Assets/Tests/EditMode/Editor/DartScoringTests.cs.meta
+++ b/Space Game/Assets/Tests/EditMode/Editor/DartScoringTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 26db1dea88cc4882905350511d9f156f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Space Game/Assets/Tests/EditMode/Editor/MissionVoteTallyTests.cs
+++ b/Space Game/Assets/Tests/EditMode/Editor/MissionVoteTallyTests.cs
@@ -1,0 +1,115 @@
+using FriendSlop.Ship;
+using NUnit.Framework;
+
+namespace FriendSlop.Tests.EditMode
+{
+    // Pins MissionVoteTally — the pure helpers behind MissionVoteBehavior.
+    // The contract:
+    //   - WinningCandidate returns null when nothing has been voted for.
+    //   - Single highest-tally wins.
+    //   - Ties resolve to the LOWEST candidate index (deterministic).
+    //   - CycleVote walks NoVote -> 0 -> 1 -> ... -> N-1 -> NoVote.
+    //   - candidateCount == 0 short-circuits to NoVote.
+    public class MissionVoteTallyTests
+    {
+        // ── WinningCandidate ───────────────────────────────────────────
+
+        [Test]
+        public void WinningCandidate_NullList_ReturnsNull()
+        {
+            Assert.IsNull(MissionVoteTally.WinningCandidate(null));
+        }
+
+        [Test]
+        public void WinningCandidate_EmptyList_ReturnsNull()
+        {
+            Assert.IsNull(MissionVoteTally.WinningCandidate(new int[0]));
+        }
+
+        [Test]
+        public void WinningCandidate_AllZeroes_ReturnsNull()
+        {
+            Assert.IsNull(MissionVoteTally.WinningCandidate(new[] { 0, 0, 0 }));
+        }
+
+        [Test]
+        public void WinningCandidate_SingleWinner_ReturnsThatIndex()
+        {
+            Assert.AreEqual(1, MissionVoteTally.WinningCandidate(new[] { 1, 3, 2 }));
+        }
+
+        [Test]
+        public void WinningCandidate_TieResolvesToLowestIndex()
+        {
+            // 2 and 2 — candidate 0 wins.
+            Assert.AreEqual(0, MissionVoteTally.WinningCandidate(new[] { 2, 2, 0 }));
+        }
+
+        [Test]
+        public void WinningCandidate_TieThreeWay_ReturnsZero()
+        {
+            Assert.AreEqual(0, MissionVoteTally.WinningCandidate(new[] { 1, 1, 1 }));
+        }
+
+        [Test]
+        public void WinningCandidate_NegativeValuesIgnored()
+        {
+            // Negative entries mean "subtract" — shouldn't happen via the
+            // behavior, but the helper must not pick them as the winner.
+            Assert.AreEqual(2, MissionVoteTally.WinningCandidate(new[] { -5, 0, 1 }));
+        }
+
+        [Test]
+        public void WinningCandidate_SinglePositiveAtLastIndex_ReturnsIt()
+        {
+            Assert.AreEqual(2, MissionVoteTally.WinningCandidate(new[] { 0, 0, 1 }));
+        }
+
+        // ── CycleVote ──────────────────────────────────────────────────
+
+        [Test]
+        public void CycleVote_FromNoVote_GoesToZero()
+        {
+            Assert.AreEqual((byte)0, MissionVoteTally.CycleVote(MissionVoteTally.NoVote, 3));
+        }
+
+        [Test]
+        public void CycleVote_FromZero_GoesToOne()
+        {
+            Assert.AreEqual((byte)1, MissionVoteTally.CycleVote(0, 3));
+        }
+
+        [Test]
+        public void CycleVote_FromOne_GoesToTwo()
+        {
+            Assert.AreEqual((byte)2, MissionVoteTally.CycleVote(1, 3));
+        }
+
+        [Test]
+        public void CycleVote_FromLastIndex_GoesToNoVote()
+        {
+            Assert.AreEqual(MissionVoteTally.NoVote, MissionVoteTally.CycleVote(2, 3));
+        }
+
+        [Test]
+        public void CycleVote_CandidateCountZero_ReturnsNoVote()
+        {
+            Assert.AreEqual(MissionVoteTally.NoVote, MissionVoteTally.CycleVote(MissionVoteTally.NoVote, 0));
+            Assert.AreEqual(MissionVoteTally.NoVote, MissionVoteTally.CycleVote(0, 0));
+        }
+
+        [Test]
+        public void CycleVote_CandidateCountNegative_ReturnsNoVote()
+        {
+            Assert.AreEqual(MissionVoteTally.NoVote, MissionVoteTally.CycleVote(0, -1));
+        }
+
+        [Test]
+        public void CycleVote_SingleCandidate_ToggleBehavior()
+        {
+            // With one candidate, the cycle is NoVote -> 0 -> NoVote.
+            Assert.AreEqual((byte)0, MissionVoteTally.CycleVote(MissionVoteTally.NoVote, 1));
+            Assert.AreEqual(MissionVoteTally.NoVote, MissionVoteTally.CycleVote(0, 1));
+        }
+    }
+}

--- a/Space Game/Assets/Tests/EditMode/Editor/MissionVoteTallyTests.cs.meta
+++ b/Space Game/Assets/Tests/EditMode/Editor/MissionVoteTallyTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 53502f60fc394b1780eaa5c2c599077e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Space Game/Assets/Tests/EditMode/Editor/SaluteWindowTests.cs
+++ b/Space Game/Assets/Tests/EditMode/Editor/SaluteWindowTests.cs
@@ -1,0 +1,174 @@
+using System.Collections.Generic;
+using FriendSlop.Ship;
+using NUnit.Framework;
+
+namespace FriendSlop.Tests.EditMode
+{
+    // Pins SaluteWindow.AllOccupiedSaluteWithinWindow — the predicate behind
+    // SaluteCoordinator's "Perfect Crew" check. Contract:
+    //   - empty occupied list -> true (vacuously satisfied; the coordinator
+    //     guards the "at least one occupied station" condition itself).
+    //   - one occupied with a recent salute -> true.
+    //   - one occupied with a stale salute -> false.
+    //   - one occupied with no salute logged -> false.
+    //   - two occupied, both recent -> true.
+    //   - two occupied, one stale -> false.
+    //   - windowSeconds <= 0 -> false (no positive window means no Perfect
+    //     Crew can fire).
+    public class SaluteWindowTests
+    {
+        private const float Now = 100f;
+        private const float Window = 1.5f;
+
+        private static IReadOnlyList<ulong> Occupants(params ulong[] ids) => ids;
+        private static IReadOnlyList<SaluteRecord> Salutes(params SaluteRecord[] records) => records;
+
+        [Test]
+        public void EmptyOccupied_ReturnsTrue()
+        {
+            Assert.IsTrue(SaluteWindow.AllOccupiedSaluteWithinWindow(
+                Occupants(),
+                Salutes(new SaluteRecord(1, Now)),
+                Now, Window));
+        }
+
+        [Test]
+        public void NullOccupied_ReturnsTrue()
+        {
+            Assert.IsTrue(SaluteWindow.AllOccupiedSaluteWithinWindow(
+                null,
+                Salutes(new SaluteRecord(1, Now)),
+                Now, Window));
+        }
+
+        [Test]
+        public void OneOccupied_RecentSalute_ReturnsTrue()
+        {
+            Assert.IsTrue(SaluteWindow.AllOccupiedSaluteWithinWindow(
+                Occupants(7),
+                Salutes(new SaluteRecord(7, Now - 0.5f)),
+                Now, Window));
+        }
+
+        [Test]
+        public void OneOccupied_SaluteAtExactWindowEdge_ReturnsTrue()
+        {
+            // 1.5s ago is on the boundary — inclusive.
+            Assert.IsTrue(SaluteWindow.AllOccupiedSaluteWithinWindow(
+                Occupants(7),
+                Salutes(new SaluteRecord(7, Now - Window)),
+                Now, Window));
+        }
+
+        [Test]
+        public void OneOccupied_StaleSalute_ReturnsFalse()
+        {
+            Assert.IsFalse(SaluteWindow.AllOccupiedSaluteWithinWindow(
+                Occupants(7),
+                Salutes(new SaluteRecord(7, Now - 5f)),
+                Now, Window));
+        }
+
+        [Test]
+        public void OneOccupied_NoSaluteLogged_ReturnsFalse()
+        {
+            Assert.IsFalse(SaluteWindow.AllOccupiedSaluteWithinWindow(
+                Occupants(7),
+                Salutes(),
+                Now, Window));
+        }
+
+        [Test]
+        public void OneOccupied_NullSalutes_ReturnsFalse()
+        {
+            Assert.IsFalse(SaluteWindow.AllOccupiedSaluteWithinWindow(
+                Occupants(7),
+                null,
+                Now, Window));
+        }
+
+        [Test]
+        public void OneOccupied_SaluteForDifferentClient_ReturnsFalse()
+        {
+            // A salute from someone else doesn't count for occupant 7.
+            Assert.IsFalse(SaluteWindow.AllOccupiedSaluteWithinWindow(
+                Occupants(7),
+                Salutes(new SaluteRecord(3, Now)),
+                Now, Window));
+        }
+
+        [Test]
+        public void TwoOccupied_BothRecent_ReturnsTrue()
+        {
+            Assert.IsTrue(SaluteWindow.AllOccupiedSaluteWithinWindow(
+                Occupants(7, 9),
+                Salutes(
+                    new SaluteRecord(7, Now - 0.2f),
+                    new SaluteRecord(9, Now - 1.0f)),
+                Now, Window));
+        }
+
+        [Test]
+        public void TwoOccupied_OneStale_ReturnsFalse()
+        {
+            Assert.IsFalse(SaluteWindow.AllOccupiedSaluteWithinWindow(
+                Occupants(7, 9),
+                Salutes(
+                    new SaluteRecord(7, Now - 0.2f),
+                    new SaluteRecord(9, Now - 5.0f)),
+                Now, Window));
+        }
+
+        [Test]
+        public void TwoOccupied_OneMissing_ReturnsFalse()
+        {
+            Assert.IsFalse(SaluteWindow.AllOccupiedSaluteWithinWindow(
+                Occupants(7, 9),
+                Salutes(new SaluteRecord(7, Now)),
+                Now, Window));
+        }
+
+        [Test]
+        public void RepeatedSalutes_LatestWins()
+        {
+            // Player double-pressed; older record is stale, latest is recent.
+            // Should still resolve true because we take the latest per client.
+            Assert.IsTrue(SaluteWindow.AllOccupiedSaluteWithinWindow(
+                Occupants(7),
+                Salutes(
+                    new SaluteRecord(7, Now - 10f),
+                    new SaluteRecord(7, Now - 0.5f)),
+                Now, Window));
+        }
+
+        [Test]
+        public void RepeatedSalutes_AllStale_ReturnsFalse()
+        {
+            Assert.IsFalse(SaluteWindow.AllOccupiedSaluteWithinWindow(
+                Occupants(7),
+                Salutes(
+                    new SaluteRecord(7, Now - 10f),
+                    new SaluteRecord(7, Now - 5f)),
+                Now, Window));
+        }
+
+        [Test]
+        public void ZeroWindow_AlwaysFalse()
+        {
+            // Even a perfectly-current salute fails if the window is zero.
+            Assert.IsFalse(SaluteWindow.AllOccupiedSaluteWithinWindow(
+                Occupants(7),
+                Salutes(new SaluteRecord(7, Now)),
+                Now, 0f));
+        }
+
+        [Test]
+        public void NegativeWindow_AlwaysFalse()
+        {
+            Assert.IsFalse(SaluteWindow.AllOccupiedSaluteWithinWindow(
+                Occupants(7),
+                Salutes(new SaluteRecord(7, Now)),
+                Now, -1f));
+        }
+    }
+}

--- a/Space Game/Assets/Tests/EditMode/Editor/SaluteWindowTests.cs.meta
+++ b/Space Game/Assets/Tests/EditMode/Editor/SaluteWindowTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8adefeac995b4148904dd1166fcac104
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
**Base: `feat/audio-cue-layer` ([#47](https://github.com/TheSchlote/Friend-Slop/pull/47)). Merge that first; this auto-retargets to `main`.**

Second slice of the **fun-loop ship-phase pass**. Refactors `ShipStation` into an orchestrator + sibling-component behavior pattern and ships four new ship-lobby gameplay activities so the between-rounds phase stops being claim-only furniture.

## Architecture: ShipStation → ShipStationBehavior

`ShipStation` keeps owning occupancy state + the interact RPC. A sibling `ShipStationBehavior` on the same GameObject (cached at `OnNetworkSpawn`) takes over `BuildPrompt` / `HandleInteractServer` / `AllowsInteract`. **When no sibling is present the existing enum-branch logic runs unchanged** — every shipped prefab keeps working through this PR even before the repair tool retrofits sibling components.

This is the architectural move that addresses the "ShipStation enum is LEAKY" finding from the architecture review: adding a 6th station type is now `new sibling subclass` + `new prefab`, no enum edit, no switch update.

## Five concrete behaviors

| Behavior | Replaces | Notes |
|---|---|---|
| **`PilotStationBehavior`** | Pilot enum branch | Claim/release + start-round in Lobby phase. Mirrors existing semantics 1:1. |
| **`LegacyOccupancyBehavior`** | Other enum branches | Claim/release only. Sibling for every non-Pilot station after the repair pass runs. |
| **`MissionVoteBehavior`** | new | 3 candidate slots, one vote per client, cycle through (no vote → 0 → 1 → 2 → no vote). Vote-winner → next-planet wiring is the queued follow-up. |
| **`BoomboxStationBehavior`** | new | Server-authoritative `trackIndex` + `isPlaying` + ServerTime-anchored start timestamp so late joiners sync. Tracks slots are empty in v1 — drop AudioClips later one at a time. State machine: stopped → track 0 → … → stopped. |
| **`DartboardStationBehavior`** | new | Hitscan dart toss (no projectile prefab). Owner sends `RequestThrowServerRpc(camera ray + charge)`; server scores via `DartScoring`; result rolls up into a session scoreboard. |

Plus **`SaluteCoordinator`** (scene-level NetworkBehaviour + `SaluteCoordinatorRegistry.Current` narrow registry mirroring `DayNightCycleRegistry`): tracks per-client salute timestamps; when every occupied station saluted within a 1.5s window, fires `PerfectCrewClientRpc`. Reuses `AudioCueId.LaunchIgnition` as the placeholder chime — proper `PerfectCrew` cue id deferred to a follow-up so the audio enum stays a single owner.

## Pure logic in `FriendSlop.Core`

All gameplay math extracted to testable pure helpers (no Netcode dependency):

- **`MissionVoteTally`** — `WinningCandidate` (lowest-index tiebreak), `CycleVote`.
- **`DartScoring`** — `ScoreForRadius` (5 concentric bands: bullseye 50 / 25 / 10 / 5 / outer 1), `FindBest`.
- **`BoomboxPlayback`** — `NextTrack` (mod track count, -1 if empty), `ComputeLocalPlaybackTime` for late-join sync.
- **`SaluteWindow`** — `AllOccupiedSaluteWithinWindow` predicate.

## Scene wiring

`FriendSlopSceneWiringRepair.cs` is already over the 400-line cap (it's on the §16d split list). Rather than appending, the new repair pass lives in a partial `FriendSlopSceneWiringRepair.ShipStationBehaviors.cs`.

The pass `EnsureStationBehaviorSiblings` adds the right sibling to every existing `ShipStation` in `ShipInterior.unity`:
- Pilot → `PilotStationBehavior`
- Every other role → `LegacyOccupancyBehavior`

**The new MissionVote / Boombox / Dartboard station GameObjects (which need new collider + visual children) are NOT created by the repair tool** — that's editor-level work. Repair only retrofits existing stations to the new pattern.

## Tests — EditMode 215 → 278 (+63)

| Suite | Tests | Surface |
|---|---|---|
| `MissionVoteTallyTests` | 15 | Empty vote → null winner, tiebreak by lowest index, cycle from each state, zero candidates returns no-vote. |
| `DartScoringTests` | 19 | Each ring band + boundary cases + miss at radius>1 + bullseye at exact 0. |
| `BoomboxPlaybackTests` | 14 | NextTrack wrap, zero count returns -1, ComputeLocalPlaybackTime mod-correctness, zero clip length returns 0. |
| `SaluteWindowTests` | 15 | Empty occupied → true, recent salute → true, stale salute → false, mixed recent+stale → false, no salute logged → false. |

Pure-logic only, mirroring the project's existing seam-coverage pattern (`LootBudgetTests`, `PlanetHazardSetTests`, `RoundStateUtilityTests`). NetworkBehaviour glue is exercised at playtest.

**Validation: EditMode 278/278 green.**

## Backward compatibility

- No scene/prefab GUIDs changed.
- `ShipStation.role` enum + every existing prefab keeps working before the repair tool runs (legacy fallback in `GetPrompt` / `RequestUseServerRpc` / `CanInteract`).
- After the repair tool runs once, every existing station has a sibling behavior component and the legacy fallback becomes dead code on those prefabs — but the fallback stays in source as defense-in-depth and documentation of the original semantics.

## Out of scope (deferred, explicitly documented)

- **Salute key binding** on `NetworkFirstPersonController.Input` — the `SaluteCoordinator` API is ready; no input touches it yet.
- **Mission Vote winner → next-planet** wiring in `RoundManager`.
- **New station GameObjects** (MissionVote board prefab, Boombox cube, Dartboard + target collider) — need editor pass.
- **`PerfectCrew` AudioCueId enum value** — parent branch (#47) owns the enum; uses `LaunchIgnition` as placeholder.
- **Carryable Boombox** — v1 is static. Lethal-Company-style portability is a future cycle.

## Architecture compliance

- ✓ No new singletons (D-014). Only `SaluteCoordinatorRegistry` static state — mirrors the established narrow-registry pattern.
- ✓ No `FindObjectsByType` in per-frame methods. `SaluteCoordinator`'s detection is event-driven inside `RequestSaluteServerRpc`, not per-tick — would have tripped `ArchitectureGuardrailTests.FrameMethodsDoNotSearchSceneObjects` otherwise.
- ✓ All files under the 400-line cap.
- ✓ Server authority for every state mutation. Every `ServerRpc` validates sender.
- ✓ No new vendor dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
